### PR TITLE
session: clean up the public API

### DIFF
--- a/example/http.go
+++ b/example/http.go
@@ -27,7 +27,6 @@ func main() {
 	ctx := context.Background()
 
 	stopRequested := false
-	reconnectCookie := ""
 	hostname := ""
 
 	logger := log15.New()
@@ -36,7 +35,6 @@ func main() {
 	for {
 		opts := libngrok.ConnectOptions().
 			WithAuthToken(os.Getenv("NGROK_TOKEN")).
-			WithReconnectCookie(reconnectCookie).
 			WithServer(os.Getenv("NGROK_SERVER")).
 			WithRegion(os.Getenv("NGROK_REGION")).
 			WithLogger(log15adapter.NewLogger(logger)).
@@ -66,13 +64,6 @@ func main() {
 
 		sess, err := libngrok.Connect(ctx, opts)
 		exitErr(err)
-
-		reconnectCookie = sess.AuthResp().Extra.Cookie
-
-		info, err := sess.SrvInfo()
-		exitErr(err)
-
-		fmt.Println("info: ", info)
 
 		tun, err := sess.StartTunnel(ctx, libngrok.
 			HTTPOptions().

--- a/libngrok_test.go
+++ b/libngrok_test.go
@@ -669,3 +669,11 @@ func TestErrors(t *testing.T) {
 	require.ErrorAs(t, err, &startErr)
 	require.IsType(t, &TCPConfig{}, startErr.Context.Config)
 }
+
+func TestNonExported(t *testing.T) {
+	ctx := context.Background()
+
+	sess := setupSession(ctx, t, nil)
+
+	require.NotEmpty(t, sess.(interface{ Region() string }).Region())
+}

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -20,3 +20,7 @@ test:
 .PHONY: coverage
 coverage: test
 	go tool cover -html cover.out
+
+docs:
+	godoc -index -http 127.0.0.1:6060 & \
+		xdg-open http://127.0.0.1:6060

--- a/session.go
+++ b/session.go
@@ -28,13 +28,6 @@ type Session interface {
 	Close() error
 
 	StartTunnel(ctx context.Context, cfg TunnelConfig) (Tunnel, error)
-
-	SrvInfo() (SrvInfo, error)
-	AuthResp() AuthResp
-
-	Heartbeat() (time.Duration, error)
-
-	Latency() <-chan time.Duration
 }
 
 const (

--- a/session.go
+++ b/session.go
@@ -324,8 +324,15 @@ func Connect(ctx context.Context, cfg *ConnectConfig) (Session, error) {
 		}
 
 		session.setInner(&sessionInner{
-			Session:  sess,
-			AuthResp: resp,
+			Session:         sess,
+			Region:          resp.Extra.Region,
+			ProtoVersion:    resp.Version,
+			ServerVersion:   resp.Extra.Version,
+			ClientID:        resp.Extra.Region,
+			AccountName:     resp.Extra.AccountName,
+			PlanName:        resp.Extra.PlanName,
+			Banner:          resp.Extra.Banner,
+			SessionDuration: resp.Extra.SessionDuration,
 		})
 
 		if cfg.LocalCallbacks.OnHeartbeat != nil {
@@ -397,7 +404,15 @@ type sessionImpl struct {
 
 type sessionInner struct {
 	tunnel_client.Session
-	AuthResp proto.AuthResp
+
+	Region          string
+	ProtoVersion    string
+	ServerVersion   string
+	ClientID        string
+	AccountName     string
+	PlanName        string
+	Banner          string
+	SessionDuration int64
 }
 
 func (s *sessionImpl) inner() *sessionInner {
@@ -441,22 +456,37 @@ func (s *sessionImpl) StartTunnel(ctx context.Context, cfg TunnelConfig) (Tunnel
 	}, nil
 }
 
-type SrvInfo proto.SrvInfoResp
-type AuthResp proto.AuthResp
+// The rest of the `sessionImpl` methods are non-public, but can be
+// interface-asserted if they're *really* needed. These are exempt from any
+// stability guarantees and subject to change without notice.
 
-func (s *sessionImpl) AuthResp() AuthResp {
-	return AuthResp(s.inner().AuthResp)
+func (s *sessionImpl) ProtoVersion() string {
+	return s.inner().ProtoVersion
 }
-
-func (s *sessionImpl) SrvInfo() (SrvInfo, error) {
-	resp, err := s.inner().SrvInfo()
-	return SrvInfo(resp), err
+func (s *sessionImpl) ServerVersion() string {
+	return s.inner().ServerVersion
 }
-
+func (s *sessionImpl) ClientID() string {
+	return s.inner().ClientID
+}
+func (s *sessionImpl) AccountName() string {
+	return s.inner().AccountName
+}
+func (s *sessionImpl) PlanName() string {
+	return s.inner().PlanName
+}
+func (s *sessionImpl) Banner() string {
+	return s.inner().Banner
+}
+func (s *sessionImpl) SessionDuration() int64 {
+	return s.inner().SessionDuration
+}
+func (s *sessionImpl) Region() string {
+	return s.inner().Region
+}
 func (s *sessionImpl) Heartbeat() (time.Duration, error) {
 	return s.inner().Heartbeat()
 }
-
 func (s *sessionImpl) Latency() <-chan time.Duration {
 	return s.inner().Latency()
 }

--- a/session.go
+++ b/session.go
@@ -105,8 +105,6 @@ type ConnectConfig struct {
 
 	CallbackErrors CallbackErrors
 
-	Cookie string
-
 	Logger log15.Logger
 }
 
@@ -198,11 +196,6 @@ func (cfg *ConnectConfig) WithLocalCallbacks(callbacks LocalCallbacks) *ConnectC
 
 func (cfg *ConnectConfig) WithRemoteCallbacks(callbacks RemoteCallbacks) *ConnectConfig {
 	cfg.RemoteCallbacks = callbacks
-	return cfg
-}
-
-func (cfg *ConnectConfig) WithReconnectCookie(cookie string) *ConnectConfig {
-	cfg.Cookie = cookie
 	return cfg
 }
 
@@ -315,8 +308,6 @@ func Connect(ctx context.Context, cfg *ConnectConfig) (Session, error) {
 		RestartUnsupportedError: remoteRestartErr,
 		StopUnsupportedError:    remoteStopErr,
 		UpdateUnsupportedError:  remoteUpdateErr,
-
-		Cookie: cfg.Cookie,
 
 		// TODO: More fields here?
 	}


### PR DESCRIPTION
Resolves a few product asks:

* Trims the `Session` interface down to just `Close` and `StartTunnel`
* Stops leaking `proto` types into the public API
* Hides the `ReconnectCookie`, making it an internal implementation detail

Most of the removed functionality is actually just hidden - it can still be accessed via interface assertions since the non-exported implementer of the `Session` interface still has the methods. I figure this should be sufficient if we ever find that we actually do need them internally for something.