### PR TITLE
configs: always copy the config structures when calling one of the methods

### DIFF
--- a/common.go
+++ b/common.go
@@ -6,9 +6,7 @@ import (
 	"github.com/ngrok/libngrok-go/internal/pb_agent"
 )
 
-type CommonConfig[T any] struct {
-	parent *T
-
+type CommonConfig struct {
 	CIDRRestrictions *CIDRRestriction
 	ProxyProto       ProxyProtoVersion
 	Metadata         string
@@ -22,19 +20,19 @@ const (
 	ProxyProtoV2 = ProxyProtoVersion(2)
 )
 
-func (cfg *CommonConfig[T]) WithProxyProto(version ProxyProtoVersion) *T {
+func (cfg *CommonConfig) WithProxyProto(version ProxyProtoVersion) *CommonConfig {
 	cfg.ProxyProto = version
-	return cfg.parent
+	return cfg
 }
 
-func (cfg *CommonConfig[T]) WithMetadata(meta string) *T {
+func (cfg *CommonConfig) WithMetadata(meta string) *CommonConfig {
 	cfg.Metadata = meta
-	return cfg.parent
+	return cfg
 }
 
-func (cfg *CommonConfig[T]) WithForwardsTo(address string) *T {
+func (cfg *CommonConfig) WithForwardsTo(address string) *CommonConfig {
 	cfg.ForwardsTo = address
-	return cfg.parent
+	return cfg
 }
 
 type CIDRRestriction struct {
@@ -81,7 +79,7 @@ func (ir *CIDRRestriction) toProtoConfig() *pb_agent.MiddlewareConfiguration_IPR
 	}
 }
 
-func (cfg *CommonConfig[T]) WithCIDRRestriction(set ...*CIDRRestriction) *T {
+func (cfg *CommonConfig) WithCIDRRestriction(set ...*CIDRRestriction) *CommonConfig {
 	if cfg.CIDRRestrictions == nil {
 		cfg.CIDRRestrictions = CIDRSet()
 	}
@@ -92,5 +90,5 @@ func (cfg *CommonConfig[T]) WithCIDRRestriction(set ...*CIDRRestriction) *T {
 			cfg.CIDRRestrictions.DenyString(s.Denied...)
 		}
 	}
-	return cfg.parent
+	return cfg
 }

--- a/labeled.go
+++ b/labeled.go
@@ -3,39 +3,40 @@ package libngrok
 import "github.com/ngrok/libngrok-go/internal/tunnel/proto"
 
 type LabeledConfig struct {
-	Labels     map[string]string
-	Metadata   string
-	ForwardsTo string
+	CommonConfig *CommonConfig
+
+	Labels map[string]string
 }
 
 func LabeledOptions() *LabeledConfig {
 	opts := &LabeledConfig{
-		Labels: map[string]string{},
+		Labels:       map[string]string{},
+		CommonConfig: &CommonConfig{},
 	}
 	return opts
 }
 
-func (lo *LabeledConfig) WithLabel(key, value string) *LabeledConfig {
-	lo.Labels[key] = value
-	return lo
+func (cfg *LabeledConfig) WithLabel(key, value string) *LabeledConfig {
+	cfg.Labels[key] = value
+	return cfg
 }
 
-func (lo *LabeledConfig) WithForwardsTo(addr string) *LabeledConfig {
-	lo.ForwardsTo = addr
-	return lo
+func (cfg *LabeledConfig) WithForwardsTo(addr string) *LabeledConfig {
+	cfg.CommonConfig = cfg.CommonConfig.WithForwardsTo(addr)
+	return cfg
 }
 
-func (lo *LabeledConfig) WithMetadata(meta string) *LabeledConfig {
-	lo.Metadata = meta
-	return lo
+func (cfg *LabeledConfig) WithMetadata(meta string) *LabeledConfig {
+	cfg.CommonConfig = cfg.CommonConfig.WithMetadata(meta)
+	return cfg
 }
 
-func (lo *LabeledConfig) tunnelConfig() tunnelConfig {
+func (cfg *LabeledConfig) tunnelConfig() tunnelConfig {
 	return tunnelConfig{
-		forwardsTo: lo.ForwardsTo,
-		labels:     lo.Labels,
+		forwardsTo: cfg.CommonConfig.ForwardsTo,
+		labels:     cfg.Labels,
 		extra: proto.BindExtra{
-			Metadata: lo.Metadata,
+			Metadata: cfg.CommonConfig.Metadata,
 		},
 	}
 }

--- a/labeled.go
+++ b/labeled.go
@@ -3,35 +3,39 @@ package libngrok
 import "github.com/ngrok/libngrok-go/internal/tunnel/proto"
 
 type LabeledConfig struct {
-	CommonConfig *CommonConfig
+	CommonConfig CommonConfig
 
 	Labels map[string]string
 }
 
-func LabeledOptions() *LabeledConfig {
-	opts := &LabeledConfig{
+func LabeledOptions() LabeledConfig {
+	opts := LabeledConfig{
 		Labels:       map[string]string{},
-		CommonConfig: &CommonConfig{},
+		CommonConfig: CommonConfig{},
 	}
 	return opts
 }
 
-func (cfg *LabeledConfig) WithLabel(key, value string) *LabeledConfig {
+func (cfg LabeledConfig) WithLabel(key, value string) LabeledConfig {
+	if cfg.Labels == nil {
+		cfg.Labels = map[string]string{}
+	}
+
 	cfg.Labels[key] = value
 	return cfg
 }
 
-func (cfg *LabeledConfig) WithForwardsTo(addr string) *LabeledConfig {
+func (cfg LabeledConfig) WithForwardsTo(addr string) LabeledConfig {
 	cfg.CommonConfig = cfg.CommonConfig.WithForwardsTo(addr)
 	return cfg
 }
 
-func (cfg *LabeledConfig) WithMetadata(meta string) *LabeledConfig {
+func (cfg LabeledConfig) WithMetadata(meta string) LabeledConfig {
 	cfg.CommonConfig = cfg.CommonConfig.WithMetadata(meta)
 	return cfg
 }
 
-func (cfg *LabeledConfig) tunnelConfig() tunnelConfig {
+func (cfg LabeledConfig) tunnelConfig() tunnelConfig {
 	return tunnelConfig{
 		forwardsTo: cfg.CommonConfig.ForwardsTo,
 		labels:     cfg.Labels,

--- a/session.go
+++ b/session.go
@@ -108,53 +108,53 @@ type ConnectConfig struct {
 	Logger log15.Logger
 }
 
-func ConnectOptions() *ConnectConfig {
-	return &ConnectConfig{}
+func ConnectOptions() ConnectConfig {
+	return ConnectConfig{}
 }
 
-func (cfg *ConnectConfig) WithMetadata(meta string) *ConnectConfig {
+func (cfg ConnectConfig) WithMetadata(meta string) ConnectConfig {
 	cfg.Metadata = meta
 	return cfg
 }
 
-func (cfg *ConnectConfig) WithDialer(dialer Dialer) *ConnectConfig {
+func (cfg ConnectConfig) WithDialer(dialer Dialer) ConnectConfig {
 	cfg.Dialer = dialer
 	return cfg
 }
 
-func (cfg *ConnectConfig) WithProxyURL(url *url.URL) *ConnectConfig {
+func (cfg ConnectConfig) WithProxyURL(url *url.URL) ConnectConfig {
 	cfg.ProxyURL = url
 	return cfg
 }
 
-func (cfg *ConnectConfig) WithResolver(resolver *net.Resolver) *ConnectConfig {
+func (cfg ConnectConfig) WithResolver(resolver *net.Resolver) ConnectConfig {
 	cfg.Resolver = resolver
 	return cfg
 }
 
-func (cfg *ConnectConfig) WithAuthToken(token string) *ConnectConfig {
+func (cfg ConnectConfig) WithAuthToken(token string) ConnectConfig {
 	cfg.AuthToken = token
 	return cfg
 }
 
-func (cfg *ConnectConfig) WithRegion(region string) *ConnectConfig {
+func (cfg ConnectConfig) WithRegion(region string) ConnectConfig {
 	if region != "" {
 		cfg.ServerAddr = fmt.Sprintf("tunnel.%s.ngrok.com:443", region)
 	}
 	return cfg
 }
 
-func (cfg *ConnectConfig) WithServer(addr string) *ConnectConfig {
+func (cfg ConnectConfig) WithServer(addr string) ConnectConfig {
 	cfg.ServerAddr = addr
 	return cfg
 }
 
-func (cfg *ConnectConfig) WithCA(pool *x509.CertPool) *ConnectConfig {
+func (cfg ConnectConfig) WithCA(pool *x509.CertPool) ConnectConfig {
 	cfg.CAPool = pool
 	return cfg
 }
 
-func (cfg *ConnectConfig) WithHeartbeatTolerance(tolerance time.Duration) *ConnectConfig {
+func (cfg ConnectConfig) WithHeartbeatTolerance(tolerance time.Duration) ConnectConfig {
 	if cfg.HeartbeatConfig == nil {
 		cfg.HeartbeatConfig = muxado.NewHeartbeatConfig()
 	}
@@ -162,7 +162,7 @@ func (cfg *ConnectConfig) WithHeartbeatTolerance(tolerance time.Duration) *Conne
 	return cfg
 }
 
-func (cfg *ConnectConfig) WithHeartbeatInterval(interval time.Duration) *ConnectConfig {
+func (cfg ConnectConfig) WithHeartbeatInterval(interval time.Duration) ConnectConfig {
 	if cfg.HeartbeatConfig == nil {
 		cfg.HeartbeatConfig = muxado.NewHeartbeatConfig()
 	}
@@ -173,7 +173,7 @@ func (cfg *ConnectConfig) WithHeartbeatInterval(interval time.Duration) *Connect
 // Log to a log15.Logger.
 // This is the logging interface that the internals use, so this is the most
 // direct way to set a logger.
-func (cfg *ConnectConfig) WithLog15(logger log15.Logger) *ConnectConfig {
+func (cfg ConnectConfig) WithLog15(logger log15.Logger) ConnectConfig {
 	cfg.Logger = logger
 	return cfg
 }
@@ -184,27 +184,27 @@ func (cfg *ConnectConfig) WithLog15(logger log15.Logger) *ConnectConfig {
 // `pgxadapter`.
 // If the provided `Logger` also implements the `log15.Logger` interface, it
 // will be used directly.
-func (cfg *ConnectConfig) WithLogger(logger Logger) *ConnectConfig {
+func (cfg ConnectConfig) WithLogger(logger Logger) ConnectConfig {
 	cfg.Logger = toLog15(logger)
 	return cfg
 }
 
-func (cfg *ConnectConfig) WithLocalCallbacks(callbacks LocalCallbacks) *ConnectConfig {
+func (cfg ConnectConfig) WithLocalCallbacks(callbacks LocalCallbacks) ConnectConfig {
 	cfg.LocalCallbacks = callbacks
 	return cfg
 }
 
-func (cfg *ConnectConfig) WithRemoteCallbacks(callbacks RemoteCallbacks) *ConnectConfig {
+func (cfg ConnectConfig) WithRemoteCallbacks(callbacks RemoteCallbacks) ConnectConfig {
 	cfg.RemoteCallbacks = callbacks
 	return cfg
 }
 
-func (cfg *ConnectConfig) WithCallbackErrors(errs CallbackErrors) *ConnectConfig {
+func (cfg ConnectConfig) WithCallbackErrors(errs CallbackErrors) ConnectConfig {
 	cfg.CallbackErrors = errs
 	return cfg
 }
 
-func Connect(ctx context.Context, cfg *ConnectConfig) (Session, error) {
+func Connect(ctx context.Context, cfg ConnectConfig) (Session, error) {
 	if cfg.Logger == nil {
 		cfg.Logger = log15.New()
 		cfg.Logger.SetHandler(log15.DiscardHandler())

--- a/tcp.go
+++ b/tcp.go
@@ -3,42 +3,41 @@ package libngrok
 import "github.com/ngrok/libngrok-go/internal/tunnel/proto"
 
 type TCPConfig struct {
-	CommonConfig *CommonConfig
+	CommonConfig CommonConfig
 	RemoteAddr   string
 }
 
-func TCPOptions() *TCPConfig {
-	opts := &TCPConfig{}
-	opts.CommonConfig = &CommonConfig{}
+func TCPOptions() TCPConfig {
+	opts := TCPConfig{}
 	return opts
 }
 
-func (cfg *TCPConfig) WithRemoteAddr(addr string) *TCPConfig {
+func (cfg TCPConfig) WithRemoteAddr(addr string) TCPConfig {
 	cfg.RemoteAddr = addr
 	return cfg
 }
 
-func (cfg *TCPConfig) WithProxyProto(version ProxyProtoVersion) *TCPConfig {
+func (cfg TCPConfig) WithProxyProto(version ProxyProtoVersion) TCPConfig {
 	cfg.CommonConfig = cfg.CommonConfig.WithProxyProto(version)
 	return cfg
 }
 
-func (cfg *TCPConfig) WithMetadata(meta string) *TCPConfig {
+func (cfg TCPConfig) WithMetadata(meta string) TCPConfig {
 	cfg.CommonConfig = cfg.CommonConfig.WithMetadata(meta)
 	return cfg
 }
 
-func (cfg *TCPConfig) WithForwardsTo(address string) *TCPConfig {
+func (cfg TCPConfig) WithForwardsTo(address string) TCPConfig {
 	cfg.CommonConfig = cfg.CommonConfig.WithForwardsTo(address)
 	return cfg
 }
 
-func (cfg *TCPConfig) WithCIDRRestriction(set ...*CIDRRestriction) *TCPConfig {
+func (cfg TCPConfig) WithCIDRRestriction(set ...CIDRRestriction) TCPConfig {
 	cfg.CommonConfig = cfg.CommonConfig.WithCIDRRestriction(set...)
 	return cfg
 }
 
-func (cfg *TCPConfig) toProtoConfig() *proto.TCPOptions {
+func (cfg TCPConfig) toProtoConfig() *proto.TCPOptions {
 	return &proto.TCPOptions{
 		Addr:          cfg.RemoteAddr,
 		IPRestriction: cfg.CommonConfig.CIDRRestrictions.toProtoConfig(),
@@ -46,7 +45,7 @@ func (cfg *TCPConfig) toProtoConfig() *proto.TCPOptions {
 	}
 }
 
-func (tcp *TCPConfig) tunnelConfig() tunnelConfig {
+func (tcp TCPConfig) tunnelConfig() tunnelConfig {
 	return tunnelConfig{
 		forwardsTo: tcp.CommonConfig.ForwardsTo,
 		proto:      "tcp",

--- a/tcp.go
+++ b/tcp.go
@@ -3,38 +3,56 @@ package libngrok
 import "github.com/ngrok/libngrok-go/internal/tunnel/proto"
 
 type TCPConfig struct {
-	CommonConfig[TCPConfig]
-	RemoteAddr string
+	CommonConfig *CommonConfig
+	RemoteAddr   string
 }
 
 func TCPOptions() *TCPConfig {
 	opts := &TCPConfig{}
-	opts.CommonConfig = CommonConfig[TCPConfig]{
-		parent: opts,
-	}
+	opts.CommonConfig = &CommonConfig{}
 	return opts
 }
 
-func (tcp *TCPConfig) WithRemoteAddr(addr string) *TCPConfig {
-	tcp.RemoteAddr = addr
-	return tcp
+func (cfg *TCPConfig) WithRemoteAddr(addr string) *TCPConfig {
+	cfg.RemoteAddr = addr
+	return cfg
 }
 
-func (tcp *TCPConfig) toProtoConfig() *proto.TCPOptions {
+func (cfg *TCPConfig) WithProxyProto(version ProxyProtoVersion) *TCPConfig {
+	cfg.CommonConfig = cfg.CommonConfig.WithProxyProto(version)
+	return cfg
+}
+
+func (cfg *TCPConfig) WithMetadata(meta string) *TCPConfig {
+	cfg.CommonConfig = cfg.CommonConfig.WithMetadata(meta)
+	return cfg
+}
+
+func (cfg *TCPConfig) WithForwardsTo(address string) *TCPConfig {
+	cfg.CommonConfig = cfg.CommonConfig.WithForwardsTo(address)
+	return cfg
+}
+
+func (cfg *TCPConfig) WithCIDRRestriction(set ...*CIDRRestriction) *TCPConfig {
+	cfg.CommonConfig = cfg.CommonConfig.WithCIDRRestriction(set...)
+	return cfg
+}
+
+func (cfg *TCPConfig) toProtoConfig() *proto.TCPOptions {
 	return &proto.TCPOptions{
-		Addr:          tcp.RemoteAddr,
-		IPRestriction: tcp.parent.CIDRRestrictions.toProtoConfig(),
-		ProxyProto:    proto.ProxyProto(tcp.parent.ProxyProto),
+		Addr:          cfg.RemoteAddr,
+		IPRestriction: cfg.CommonConfig.CIDRRestrictions.toProtoConfig(),
+		ProxyProto:    proto.ProxyProto(cfg.CommonConfig.ProxyProto),
 	}
 }
 
 func (tcp *TCPConfig) tunnelConfig() tunnelConfig {
 	return tunnelConfig{
-		forwardsTo: tcp.ForwardsTo,
+		forwardsTo: tcp.CommonConfig.ForwardsTo,
 		proto:      "tcp",
 		opts:       tcp.toProtoConfig(),
 		extra: proto.BindExtra{
-			Metadata: tcp.Metadata,
+			Metadata: tcp.CommonConfig.Metadata,
 		},
 	}
 }

--- a/tls.go
+++ b/tls.go
@@ -9,22 +9,16 @@ import (
 )
 
 type TLSCommon struct {
-	Domain      string
 	MutualTLSCA []*x509.Certificate
 }
 
-func (cfg *TLSCommon) WithDomain(name string) *TLSCommon {
-	cfg.Domain = name
-	return cfg
-}
-
-func (cfg *TLSCommon) WithMutualTLSCA(certs ...*x509.Certificate) *TLSCommon {
+func (cfg TLSCommon) WithMutualTLSCA(certs ...*x509.Certificate) TLSCommon {
 	cfg.MutualTLSCA = append(cfg.MutualTLSCA, certs...)
 	return cfg
 }
 
-func (cfg *TLSCommon) toProtoConfig() *pb_agent.MiddlewareConfiguration_MutualTLS {
-	if cfg == nil || cfg.MutualTLSCA == nil {
+func (cfg TLSCommon) toProtoConfig() *pb_agent.MiddlewareConfiguration_MutualTLS {
+	if cfg.MutualTLSCA == nil {
 		return nil
 	}
 	opts := &pb_agent.MiddlewareConfiguration_MutualTLS{}
@@ -35,59 +29,59 @@ func (cfg *TLSCommon) toProtoConfig() *pb_agent.MiddlewareConfiguration_MutualTL
 }
 
 type TLSConfig struct {
-	TLSCommon    *TLSCommon
-	CommonConfig *CommonConfig
+	TLSCommon    TLSCommon
+	CommonConfig CommonConfig
+
+	Domain string
 
 	KeyPEM  []byte
 	CertPEM []byte
 }
 
-func (cfg *TLSConfig) WithTermination(certPEM, keyPEM []byte) *TLSConfig {
+func (cfg TLSConfig) WithTermination(certPEM, keyPEM []byte) TLSConfig {
 	cfg.CertPEM = certPEM
 	cfg.KeyPEM = keyPEM
 	return cfg
 }
 
-func TLSOptions() *TLSConfig {
-	opts := &TLSConfig{}
-	opts.TLSCommon = &TLSCommon{}
-	opts.CommonConfig = &CommonConfig{}
+func TLSOptions() TLSConfig {
+	opts := TLSConfig{}
 	return opts
 }
 
-func (cfg *TLSConfig) WithDomain(name string) *TLSConfig {
-	cfg.TLSCommon = cfg.TLSCommon.WithDomain(name)
+func (cfg TLSConfig) WithDomain(name string) TLSConfig {
+	cfg.Domain = name
 	return cfg
 }
 
-func (cfg *TLSConfig) WithMutualTLSCA(certs ...*x509.Certificate) *TLSConfig {
+func (cfg TLSConfig) WithMutualTLSCA(certs ...*x509.Certificate) TLSConfig {
 	cfg.TLSCommon = cfg.TLSCommon.WithMutualTLSCA(certs...)
 	return cfg
 }
 
-func (cfg *TLSConfig) WithProxyProto(version ProxyProtoVersion) *TLSConfig {
+func (cfg TLSConfig) WithProxyProto(version ProxyProtoVersion) TLSConfig {
 	cfg.CommonConfig = cfg.CommonConfig.WithProxyProto(version)
 	return cfg
 }
 
-func (cfg *TLSConfig) WithMetadata(meta string) *TLSConfig {
+func (cfg TLSConfig) WithMetadata(meta string) TLSConfig {
 	cfg.CommonConfig = cfg.CommonConfig.WithMetadata(meta)
 	return cfg
 }
 
-func (cfg *TLSConfig) WithForwardsTo(address string) *TLSConfig {
+func (cfg TLSConfig) WithForwardsTo(address string) TLSConfig {
 	cfg.CommonConfig = cfg.CommonConfig.WithForwardsTo(address)
 	return cfg
 }
 
-func (cfg *TLSConfig) WithCIDRRestriction(set ...*CIDRRestriction) *TLSConfig {
+func (cfg TLSConfig) WithCIDRRestriction(set ...CIDRRestriction) TLSConfig {
 	cfg.CommonConfig = cfg.CommonConfig.WithCIDRRestriction(set...)
 	return cfg
 }
 
-func (cfg *TLSConfig) toProtoConfig() *proto.TLSOptions {
+func (cfg TLSConfig) toProtoConfig() *proto.TLSOptions {
 	opts := &proto.TLSOptions{
-		Hostname:   cfg.TLSCommon.Domain,
+		Hostname:   cfg.Domain,
 		ProxyProto: proto.ProxyProto(cfg.CommonConfig.ProxyProto),
 	}
 
@@ -103,7 +97,7 @@ func (cfg *TLSConfig) toProtoConfig() *proto.TLSOptions {
 	return opts
 }
 
-func (cfg *TLSConfig) tunnelConfig() tunnelConfig {
+func (cfg TLSConfig) tunnelConfig() tunnelConfig {
 	return tunnelConfig{
 		forwardsTo: cfg.CommonConfig.ForwardsTo,
 		proto:      "tls",

--- a/tunnel_config.go
+++ b/tunnel_config.go
@@ -3,14 +3,14 @@ package libngrok
 import "github.com/ngrok/libngrok-go/internal/tunnel/proto"
 
 type tunnelConfig struct {
-	// Note: Only one set of options should be set at a time - either proto,
-	// opts, and extra, or labels and metadata.
+	// Note: Only one set of options should be set at a time - either proto and
+	// opts or only labels
 	forwardsTo string
+	extra      proto.BindExtra
 
 	// HTTP(s), TCP, and TLS tunnels
 	proto string
 	opts  any
-	extra proto.BindExtra
 
 	// Labeled tunnels
 	labels map[string]string


### PR DESCRIPTION
WIP-ish - still not sure if this is the right move. Builds on #12.

Modifying the receiver *and* returning it combines a couple of approaches to the builder/method chaining pattern, which is kinda weird.

This makes it so that all of the methods take a value receiver and perform an implicit copy that then gets returned. This is fine-ish, and makes it so that the zero values are actually useful, which may remove the need for the config constructor methods, but is something of a false promise when map or slice fields are modified. We could force a copy of those, but that ends up getting noisy with dubious benefits.