### PR TITLE
tunnels: auto-define ForwardsTo

### DIFF
--- a/example/http.go
+++ b/example/http.go
@@ -68,8 +68,7 @@ func main() {
 		tun, err := sess.StartTunnel(ctx, libngrok.
 			HTTPOptions().
 			WithDomain(hostname).
-			WithMetadata(`{"foo":"bar"}`).
-			WithForwardsTo("foobarbaz"),
+			WithMetadata(`{"foo":"bar"}`),
 		)
 		exitErr(err)
 

--- a/http.go
+++ b/http.go
@@ -262,16 +262,13 @@ func (cfg *HTTPConfig) toProtoConfig() *proto.HTTPOptions {
 	return opts
 }
 
-func (cfg *HTTPConfig) tunnelConfig() tunnelConfig {
+func (cfg *HTTPConfig) applyTunnelConfig(tcfg *tunnelConfig) {
 	if cfg.Scheme == "" {
 		cfg.Scheme = SchemeHTTPS
 	}
-	return tunnelConfig{
-		forwardsTo: cfg.CommonConfig.ForwardsTo,
-		proto:      string(cfg.Scheme),
-		opts:       cfg.toProtoConfig(),
-		extra: proto.BindExtra{
-			Metadata: cfg.CommonConfig.Metadata,
-		},
-	}
+
+	cfg.CommonConfig.applyTunnelConfig(tcfg)
+
+	tcfg.proto = string(cfg.Scheme)
+	tcfg.opts = cfg.toProtoConfig()
 }

--- a/labeled.go
+++ b/labeled.go
@@ -1,7 +1,5 @@
 package libngrok
 
-import "github.com/ngrok/libngrok-go/internal/tunnel/proto"
-
 type LabeledConfig struct {
 	CommonConfig *CommonConfig
 
@@ -31,12 +29,8 @@ func (cfg *LabeledConfig) WithMetadata(meta string) *LabeledConfig {
 	return cfg
 }
 
-func (cfg *LabeledConfig) tunnelConfig() tunnelConfig {
-	return tunnelConfig{
-		forwardsTo: cfg.CommonConfig.ForwardsTo,
-		labels:     cfg.Labels,
-		extra: proto.BindExtra{
-			Metadata: cfg.CommonConfig.Metadata,
-		},
-	}
+func (cfg *LabeledConfig) applyTunnelConfig(tcfg *tunnelConfig) {
+	cfg.CommonConfig.applyTunnelConfig(tcfg)
+
+	tcfg.labels = cfg.Labels
 }

--- a/session.go
+++ b/session.go
@@ -437,7 +437,8 @@ func (s *sessionImpl) StartTunnel(ctx context.Context, cfg TunnelConfig) (Tunnel
 		err    error
 	)
 
-	tunnelCfg := cfg.tunnelConfig()
+	tunnelCfg := &tunnelConfig{}
+	cfg.applyTunnelConfig(tunnelCfg)
 
 	if tunnelCfg.proto != "" {
 		tunnel, err = s.inner().Listen(tunnelCfg.proto, tunnelCfg.opts, tunnelCfg.extra, tunnelCfg.forwardsTo)

--- a/tcp.go
+++ b/tcp.go
@@ -46,13 +46,9 @@ func (cfg *TCPConfig) toProtoConfig() *proto.TCPOptions {
 	}
 }
 
-func (tcp *TCPConfig) tunnelConfig() tunnelConfig {
-	return tunnelConfig{
-		forwardsTo: tcp.CommonConfig.ForwardsTo,
-		proto:      "tcp",
-		opts:       tcp.toProtoConfig(),
-		extra: proto.BindExtra{
-			Metadata: tcp.CommonConfig.Metadata,
-		},
-	}
+func (cfg *TCPConfig) applyTunnelConfig(tcfg *tunnelConfig) {
+	cfg.CommonConfig.applyTunnelConfig(tcfg)
+
+	tcfg.proto = "tcp"
+	tcfg.opts = cfg.toProtoConfig()
 }

--- a/tls.go
+++ b/tls.go
@@ -103,13 +103,9 @@ func (cfg *TLSConfig) toProtoConfig() *proto.TLSOptions {
 	return opts
 }
 
-func (cfg *TLSConfig) tunnelConfig() tunnelConfig {
-	return tunnelConfig{
-		forwardsTo: cfg.CommonConfig.ForwardsTo,
-		proto:      "tls",
-		opts:       cfg.toProtoConfig(),
-		extra: proto.BindExtra{
-			Metadata: cfg.CommonConfig.Metadata,
-		},
-	}
+func (cfg *TLSConfig) applyTunnelConfig(tcfg *tunnelConfig) {
+	cfg.CommonConfig.applyTunnelConfig(tcfg)
+
+	tcfg.proto = "tls"
+	tcfg.opts = cfg.toProtoConfig()
 }

--- a/tunnel_config.go
+++ b/tunnel_config.go
@@ -17,5 +17,5 @@ type tunnelConfig struct {
 }
 
 type TunnelConfig interface {
-	tunnelConfig() tunnelConfig
+	applyTunnelConfig(cfg *tunnelConfig)
 }


### PR DESCRIPTION
Right now it's in the format `app://<hostname>/<executable path>?pid=<process id>`.

We can bikeshed here.

Builds on #12, which should be merged first.