### PR TITLE
errors: remove contexts, generics, and type aliases

### DIFF
--- a/errors_test.go
+++ b/errors_test.go
@@ -9,10 +9,10 @@ import (
 
 var testError = errors.New("testing, 1 2 3!")
 
-// Sanity check for my appraoch to error construction/wrapping
-func TestErrorStrategy(t *testing.T) {
+// Sanity check for the appraoch to error construction/wrapping
+func TestErrorWrapping(t *testing.T) {
 	var accept error = ErrAcceptFailed{Inner: testError}
-	var auth error = ErrAuthFailed{accept, AuthFailedContext{Remote: true}}
+	var auth error = ErrAuthFailed{true, accept}
 
 	require.True(t, errors.Is(accept, ErrAcceptFailed{}))
 	require.True(t, errors.Is(auth, ErrAuthFailed{}))
@@ -26,5 +26,5 @@ func TestErrorStrategy(t *testing.T) {
 
 	require.True(t, errors.As(accept, &downcastAccept))
 
-	require.True(t, downcastAuth.Context.Remote)
+	require.True(t, downcastAuth.Remote)
 }

--- a/libngrok_test.go
+++ b/libngrok_test.go
@@ -659,7 +659,7 @@ func TestErrors(t *testing.T) {
 	var authErr ErrAuthFailed
 	require.ErrorIs(t, err, authErr)
 	require.ErrorAs(t, err, &authErr)
-	require.True(t, authErr.Context.Remote)
+	require.True(t, authErr.Remote)
 
 	sess, err := Connect(ctx, ConnectOptions())
 	require.NoError(t, err)
@@ -667,7 +667,7 @@ func TestErrors(t *testing.T) {
 	var startErr ErrStartTunnel
 	require.ErrorIs(t, err, startErr)
 	require.ErrorAs(t, err, &startErr)
-	require.IsType(t, &TCPConfig{}, startErr.Context.Config)
+	require.IsType(t, &TCPConfig{}, startErr.Config)
 }
 
 func TestNonExported(t *testing.T) {

--- a/session.go
+++ b/session.go
@@ -237,7 +237,7 @@ func Connect(ctx context.Context, cfg *ConnectConfig) (Session, error) {
 		if cfg.ProxyURL != nil {
 			proxied, err := proxy.FromURL(cfg.ProxyURL, netDialer)
 			if err != nil {
-				return nil, ErrProxyInit{err, ProxyInitContext{cfg.ProxyURL}}
+				return nil, ErrProxyInit{cfg.ProxyURL, err}
 			}
 			dialer = proxied.(Dialer)
 		} else {
@@ -262,7 +262,7 @@ func Connect(ctx context.Context, cfg *ConnectConfig) (Session, error) {
 	rawDialer := func() (tunnel_client.RawSession, error) {
 		conn, err := dialer.DialContext(ctx, "tcp", cfg.ServerAddr)
 		if err != nil {
-			return nil, ErrSessionDial{err, DialContext{cfg.ServerAddr}}
+			return nil, ErrSessionDial{cfg.ServerAddr, err}
 		}
 
 		conn = tls.Client(conn, tlsConfig)
@@ -320,7 +320,7 @@ func Connect(ctx context.Context, cfg *ConnectConfig) (Session, error) {
 				err = errors.New(resp.Error)
 				remote = true
 			}
-			return ErrAuthFailed{err, AuthFailedContext{remote}}
+			return ErrAuthFailed{remote, err}
 		}
 
 		session.setInner(&sessionInner{
@@ -446,9 +446,7 @@ func (s *sessionImpl) StartTunnel(ctx context.Context, cfg TunnelConfig) (Tunnel
 	}
 
 	if err != nil {
-		return nil, ErrStartTunnel{err, StartContext{
-			Config: cfg,
-		}}
+		return nil, ErrStartTunnel{cfg, err}
 	}
 
 	return &tunnelImpl{


### PR DESCRIPTION
Simplifies errors to a handful of concrete types.

More boilerplate, but nicer for consumers.