### PR TITLE
callbacks: use an interceptor approach to the connect callback

### DIFF
--- a/libngrok_test.go
+++ b/libngrok_test.go
@@ -578,8 +578,10 @@ func TestConnectcionCallbacks(t *testing.T) {
 	disconnectErrs := 0
 	disconnectNils := 0
 	sess := setupSession(ctx, t, ConnectOptions().WithLocalCallbacks(LocalCallbacks{
-		OnConnect: func(ctx context.Context, sess Session) {
+		OnConnect: func(ctx context.Context, connect ConnectFunction) error {
+			_, err := connect(ctx)
 			connects += 1
+			return err
 		},
 		OnDisconnect: func(ctx context.Context, sess Session, err error) {
 			if err == nil {


### PR DESCRIPTION
I don't love this.

It's kinda what was asked for, but also kinda not.

To start with: The `ReconnectingSession` provided by `lib/tunnel` doesn't give us the ability to intercept a reconnect before the connection is established - only the initial session bootstrap which does authentication. We could rework `ReconnectingSession` to support full interception, but it would make it diverge further from the original implementation.

Then there are the questions around arguments/return values. What's useful to let consumers change? We could probably let them trade the existing session for a completely new one[^1], but allowing them to intercept and change auth stuff is fraught if we're managing the reconnect cookie internally.

[^1]: Would probably involve some refactoring of the `sessionImpl` swapping, but seems doable.