### PR TITLE
Rebrand libngrok to ngrok

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# libngrok-go
+# ngrok-go
 
 **Note: This is alpha-quality software. Interfaces are subject to change
 without warning**
 
 This is the ngrok agent in library form, suitable for integrating directly into
 an application. See `example/http.go` for example usage, or the tests in
-`libngrok_test.go`.
+`online_test.go`.
 
 ## License
 
-libngrok-go is licensed under the terms of the MIT license.
+ngrok-go is licensed under the terms of the MIT license.
 
 See [LICENSE](./LICENSE) for details.

--- a/common.go
+++ b/common.go
@@ -1,4 +1,4 @@
-package libngrok
+package ngrok
 
 import (
 	"fmt"
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/ngrok/libngrok-go/internal/pb_agent"
+	"github.com/ngrok/ngrok-go/internal/pb_agent"
 )
 
 type CommonConfig struct {

--- a/errors.go
+++ b/errors.go
@@ -1,4 +1,4 @@
-package libngrok
+package ngrok
 
 import (
 	"fmt"

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,4 +1,4 @@
-package libngrok
+package ngrok
 
 import (
 	"errors"

--- a/example/go.mod
+++ b/example/go.mod
@@ -1,12 +1,12 @@
-module github.com/ngrok/libngrok-go/examples
+module github.com/ngrok/ngrok-go/examples
 
 go 1.18
 
 require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/inconshreveable/log15 v0.0.0-20201112154412-8562bdadbbac
-	github.com/ngrok/libngrok-go v0.0.0
-	github.com/ngrok/libngrok-go/log/log15adapter v0.0.0
+	github.com/ngrok/ngrok-go v0.0.0
+	github.com/ngrok/ngrok-go/log/log15adapter v0.0.0
 )
 
 require (
@@ -14,14 +14,14 @@ require (
 	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
-	github.com/ngrok/libngrok-go/log v0.0.0 // indirect
+	github.com/ngrok/ngrok-go/log v0.0.0 // indirect
 	golang.org/x/net v0.0.0-20220812174116-3211cb980234 // indirect
 	golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 )
 
 replace (
-	github.com/ngrok/libngrok-go => ../
-	github.com/ngrok/libngrok-go/log => ../log
-	github.com/ngrok/libngrok-go/log/log15adapter => ../log/log15adapter
+	github.com/ngrok/ngrok-go => ../
+	github.com/ngrok/ngrok-go/log => ../log
+	github.com/ngrok/ngrok-go/log/log15adapter => ../log/log15adapter
 )

--- a/example/http.go
+++ b/example/http.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/inconshreveable/log15"
-	libngrok "github.com/ngrok/libngrok-go"
-	"github.com/ngrok/libngrok-go/log/log15adapter"
+	ngrok "github.com/ngrok/ngrok-go"
+	"github.com/ngrok/ngrok-go/log/log15adapter"
 )
 
 func exitErr(err error) {
@@ -33,19 +33,19 @@ func main() {
 	logger.SetHandler(log15.LvlFilterHandler(log15.LvlInfo, log15.StderrHandler))
 
 	for {
-		opts := libngrok.ConnectOptions().
+		opts := ngrok.ConnectOptions().
 			WithAuthtoken(os.Getenv("NGROK_TOKEN")).
 			WithServer(os.Getenv("NGROK_SERVER")).
 			WithRegion(os.Getenv("NGROK_REGION")).
 			WithLogger(log15adapter.NewLogger(logger)).
 			WithMetadata("Hello, world!").
-			WithRemoteCallbacks(libngrok.RemoteCallbacks{
-				OnStop: func(_ context.Context, sess libngrok.Session) error {
+			WithRemoteCallbacks(ngrok.RemoteCallbacks{
+				OnStop: func(_ context.Context, sess ngrok.Session) error {
 					fmt.Println("got remote stop")
 					stopRequested = true
 					return nil
 				},
-				OnRestart: func(_ context.Context, sess libngrok.Session) error {
+				OnRestart: func(_ context.Context, sess ngrok.Session) error {
 					fmt.Println("got remote restart")
 					return nil
 				},
@@ -62,10 +62,10 @@ func main() {
 			opts.WithCA(pool)
 		}
 
-		sess, err := libngrok.Connect(ctx, opts)
+		sess, err := ngrok.Connect(ctx, opts)
 		exitErr(err)
 
-		tun, err := sess.StartTunnel(ctx, libngrok.
+		tun, err := sess.StartTunnel(ctx, ngrok.
 			HTTPOptions().
 			WithDomain(hostname).
 			WithMetadata(`{"foo":"bar"}`),

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ngrok/libngrok-go
+module github.com/ngrok/ngrok-go
 
 go 1.18
 

--- a/go.work
+++ b/go.work
@@ -15,8 +15,8 @@ use (
 )
 
 replace (
-	github.com/ngrok/libngrok-go v0.0.0 => ./
-	github.com/ngrok/libngrok-go/log v0.0.0 => ./log
-	github.com/ngrok/libngrok-go/log/log15adapter v0.0.0 => ./log/log15adapter
-	github.com/ngrok/libngrok-go/log/pgxadapter v0.0.0 => ./log/pgxadapter
+	github.com/ngrok/ngrok-go v0.0.0 => ./
+	github.com/ngrok/ngrok-go/log v0.0.0 => ./log
+	github.com/ngrok/ngrok-go/log/log15adapter v0.0.0 => ./log/log15adapter
+	github.com/ngrok/ngrok-go/log/pgxadapter v0.0.0 => ./log/pgxadapter
 )

--- a/http.go
+++ b/http.go
@@ -1,11 +1,11 @@
-package libngrok
+package ngrok
 
 import (
 	"crypto/x509"
 	"fmt"
 
-	"github.com/ngrok/libngrok-go/internal/pb_agent"
-	"github.com/ngrok/libngrok-go/internal/tunnel/proto"
+	"github.com/ngrok/ngrok-go/internal/pb_agent"
+	"github.com/ngrok/ngrok-go/internal/tunnel/proto"
 )
 
 type Scheme string

--- a/internal/muxado/config.go
+++ b/internal/muxado/config.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"sync"
 
-	"github.com/ngrok/libngrok-go/internal/muxado/frame"
+	"github.com/ngrok/ngrok-go/internal/muxado/frame"
 )
 
 var zeroConfig Config

--- a/internal/muxado/errors.go
+++ b/internal/muxado/errors.go
@@ -3,7 +3,7 @@ package muxado
 import (
 	"errors"
 
-	"github.com/ngrok/libngrok-go/internal/muxado/frame"
+	"github.com/ngrok/ngrok-go/internal/muxado/frame"
 )
 
 // ErrorCode is a 32-bit integer indicating the type of an error condition

--- a/internal/muxado/session.go
+++ b/internal/muxado/session.go
@@ -9,7 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/ngrok/libngrok-go/internal/muxado/frame"
+	"github.com/ngrok/ngrok-go/internal/muxado/frame"
 )
 
 // private interface for Sessions to call Streams

--- a/internal/muxado/session_test.go
+++ b/internal/muxado/session_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ngrok/libngrok-go/internal/muxado/frame"
+	"github.com/ngrok/ngrok-go/internal/muxado/frame"
 )
 
 func newFakeStream(sess sessionPrivate, id frame.StreamId, windowSize uint32, fin bool, init bool) streamPrivate {

--- a/internal/muxado/stream.go
+++ b/internal/muxado/stream.go
@@ -9,7 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/ngrok/libngrok-go/internal/muxado/frame"
+	"github.com/ngrok/ngrok-go/internal/muxado/frame"
 )
 
 var (

--- a/internal/muxado/stream_map.go
+++ b/internal/muxado/stream_map.go
@@ -3,7 +3,7 @@ package muxado
 import (
 	"sync"
 
-	"github.com/ngrok/libngrok-go/internal/muxado/frame"
+	"github.com/ngrok/ngrok-go/internal/muxado/frame"
 )
 
 const (

--- a/internal/muxado/stream_test.go
+++ b/internal/muxado/stream_test.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/ngrok/libngrok-go/internal/muxado/frame"
+	"github.com/ngrok/ngrok-go/internal/muxado/frame"
 )
 
 func TestCloseWrite(t *testing.T) {

--- a/internal/tunnel/client/raw_session.go
+++ b/internal/tunnel/client/raw_session.go
@@ -9,9 +9,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ngrok/libngrok-go/internal/muxado"
-	"github.com/ngrok/libngrok-go/internal/tunnel/netx"
-	"github.com/ngrok/libngrok-go/internal/tunnel/proto"
+	"github.com/ngrok/ngrok-go/internal/muxado"
+	"github.com/ngrok/ngrok-go/internal/tunnel/netx"
+	"github.com/ngrok/ngrok-go/internal/tunnel/proto"
 
 	log "github.com/inconshreveable/log15"
 	logext "github.com/inconshreveable/log15/ext"

--- a/internal/tunnel/client/raw_session_test.go
+++ b/internal/tunnel/client/raw_session_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/inconshreveable/log15"
-	"github.com/ngrok/libngrok-go/internal/muxado"
+	"github.com/ngrok/ngrok-go/internal/muxado"
 )
 
 type dummyStream struct{}

--- a/internal/tunnel/client/reconnecting.go
+++ b/internal/tunnel/client/reconnecting.go
@@ -8,8 +8,8 @@ import (
 
 	log "github.com/inconshreveable/log15"
 	"github.com/jpillora/backoff"
-	"github.com/ngrok/libngrok-go/internal/tunnel/netx"
-	"github.com/ngrok/libngrok-go/internal/tunnel/proto"
+	"github.com/ngrok/ngrok-go/internal/tunnel/netx"
+	"github.com/ngrok/ngrok-go/internal/tunnel/proto"
 )
 
 var ErrSessionNotReady = errors.New("an ngrok tunnel session has not yet been established")

--- a/internal/tunnel/client/session.go
+++ b/internal/tunnel/client/session.go
@@ -10,11 +10,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ngrok/libngrok-go/internal/tunnel/netx"
-	"github.com/ngrok/libngrok-go/internal/tunnel/proto"
+	"github.com/ngrok/ngrok-go/internal/tunnel/netx"
+	"github.com/ngrok/ngrok-go/internal/tunnel/proto"
 
 	log "github.com/inconshreveable/log15"
-	muxado "github.com/ngrok/libngrok-go/internal/muxado"
+	muxado "github.com/ngrok/ngrok-go/internal/muxado"
 )
 
 // Session is a higher-level client session interface. You will almost always prefer this over

--- a/internal/tunnel/client/tunnel.go
+++ b/internal/tunnel/client/tunnel.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"sync/atomic"
 
-	"github.com/ngrok/libngrok-go/internal/tunnel/proto"
+	"github.com/ngrok/ngrok-go/internal/tunnel/proto"
 )
 
 type Tunnel interface {

--- a/internal/tunnel/proto/msg.go
+++ b/internal/tunnel/proto/msg.go
@@ -1,9 +1,9 @@
 package proto
 
 import (
-	"github.com/ngrok/libngrok-go/internal/pb_agent"
+	"github.com/ngrok/ngrok-go/internal/pb_agent"
 
-	"github.com/ngrok/libngrok-go/internal/muxado"
+	"github.com/ngrok/ngrok-go/internal/muxado"
 )
 
 type ReqType muxado.StreamType

--- a/labeled.go
+++ b/labeled.go
@@ -1,4 +1,4 @@
-package libngrok
+package ngrok
 
 type LabeledConfig struct {
 	CommonConfig *CommonConfig

--- a/log/go.mod
+++ b/log/go.mod
@@ -1,3 +1,3 @@
-module github.com/ngrok/libngrok-go/log
+module github.com/ngrok/ngrok-go/log
 
 go 1.18

--- a/log/log15adapter/adapter.go
+++ b/log/log15adapter/adapter.go
@@ -4,10 +4,10 @@ import (
 	"context"
 
 	"github.com/inconshreveable/log15"
-	"github.com/ngrok/libngrok-go/log"
+	"github.com/ngrok/ngrok-go/log"
 )
 
-// Wrapper for a log15.Logger to add the libngrok logging interface.
+// Wrapper for a log15.Logger to add the ngrok logging interface.
 // Also exposes the log15.Logger interface directly so that it can be downcast
 // to the log15.Logger.
 type Logger struct {

--- a/log/log15adapter/go.mod
+++ b/log/log15adapter/go.mod
@@ -1,10 +1,10 @@
-module github.com/ngrok/libngrok-go/log/log15adapter
+module github.com/ngrok/ngrok-go/log/log15adapter
 
 go 1.18
 
 require (
 	github.com/inconshreveable/log15 v0.0.0-20201112154412-8562bdadbbac
-	github.com/ngrok/libngrok-go/log v0.0.0
+	github.com/ngrok/ngrok-go/log v0.0.0
 )
 
 require (
@@ -14,4 +14,4 @@ require (
 	golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 // indirect
 )
 
-replace github.com/ngrok/libngrok-go/log => ../
+replace github.com/ngrok/ngrok-go/log => ../

--- a/log/pgxadapter/adapter.go
+++ b/log/pgxadapter/adapter.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/jackc/pgx/v4"
-	"github.com/ngrok/libngrok-go/log"
+	"github.com/ngrok/ngrok-go/log"
 )
 
 // Adapter for the pgx logging interface.

--- a/log/pgxadapter/go.mod
+++ b/log/pgxadapter/go.mod
@@ -1,10 +1,10 @@
-module github.com/ngrok/libngrok-go/log/pgxadapter
+module github.com/ngrok/ngrok-go/log/pgxadapter
 
 go 1.18
 
 require (
 	github.com/jackc/pgx/v4 v4.17.0
-	github.com/ngrok/libngrok-go/log v0.0.0
+	github.com/ngrok/ngrok-go/log v0.0.0
 )
 
 require (
@@ -19,4 +19,4 @@ require (
 	golang.org/x/text v0.3.7 // indirect
 )
 
-replace github.com/ngrok/libngrok-go/log => ../
+replace github.com/ngrok/ngrok-go/log => ../

--- a/logging.go
+++ b/logging.go
@@ -1,4 +1,4 @@
-package libngrok
+package ngrok
 
 import (
 	"context"
@@ -19,9 +19,9 @@ const (
 )
 
 // Logger defines a logging interface. It is identical to the log.Logger
-// interface in [github.com/ngrok/libngrok-go/log.Logger]. It is duplicated here to avoid having to
+// interface in [github.com/ngrok/ngrok-go/log.Logger]. It is duplicated here to avoid having to
 // unconditionally import that submodule. Documentation lives in the
-// [github.com/ngrok/libngrok-go/log.Logger] submodule, as well as adapters for other logging libraries.
+// [github.com/ngrok/ngrok-go/log.Logger] submodule, as well as adapters for other logging libraries.
 type Logger interface {
 	// Log a message at the given level with data key/value pairs. data may be nil.
 	Log(context context.Context, level LogLevel, msg string, data map[string]interface{})

--- a/ngrok.go
+++ b/ngrok.go
@@ -1,4 +1,4 @@
-package libngrok
+package ngrok
 
 import "context"
 

--- a/online_test.go
+++ b/online_test.go
@@ -1,4 +1,4 @@
-package libngrok
+package ngrok
 
 import (
 	"compress/gzip"

--- a/session.go
+++ b/session.go
@@ -1,4 +1,4 @@
-package libngrok
+package ngrok
 
 import (
 	"context"
@@ -16,9 +16,9 @@ import (
 	"unsafe"
 
 	"github.com/inconshreveable/log15"
-	"github.com/ngrok/libngrok-go/internal/muxado"
-	tunnel_client "github.com/ngrok/libngrok-go/internal/tunnel/client"
-	"github.com/ngrok/libngrok-go/internal/tunnel/proto"
+	"github.com/ngrok/ngrok-go/internal/muxado"
+	tunnel_client "github.com/ngrok/ngrok-go/internal/tunnel/client"
+	"github.com/ngrok/ngrok-go/internal/tunnel/proto"
 	"golang.org/x/net/proxy"
 )
 

--- a/tcp.go
+++ b/tcp.go
@@ -1,6 +1,6 @@
-package libngrok
+package ngrok
 
-import "github.com/ngrok/libngrok-go/internal/tunnel/proto"
+import "github.com/ngrok/ngrok-go/internal/tunnel/proto"
 
 type TCPConfig struct {
 	CommonConfig *CommonConfig

--- a/tls.go
+++ b/tls.go
@@ -1,11 +1,11 @@
-package libngrok
+package ngrok
 
 import (
 	"crypto/x509"
 	"encoding/pem"
 
-	"github.com/ngrok/libngrok-go/internal/pb_agent"
-	"github.com/ngrok/libngrok-go/internal/tunnel/proto"
+	"github.com/ngrok/ngrok-go/internal/pb_agent"
+	"github.com/ngrok/ngrok-go/internal/tunnel/proto"
 )
 
 type TLSCommon struct {

--- a/tunnel.go
+++ b/tunnel.go
@@ -1,4 +1,4 @@
-package libngrok
+package ngrok
 
 import (
 	"context"
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"time"
 
-	tunnel_client "github.com/ngrok/libngrok-go/internal/tunnel/client"
+	tunnel_client "github.com/ngrok/ngrok-go/internal/tunnel/client"
 )
 
 type Tunnel interface {

--- a/tunnel_config.go
+++ b/tunnel_config.go
@@ -1,6 +1,6 @@
-package libngrok
+package ngrok
 
-import "github.com/ngrok/libngrok-go/internal/tunnel/proto"
+import "github.com/ngrok/ngrok-go/internal/tunnel/proto"
 
 type tunnelConfig struct {
 	// Note: Only one set of options should be set at a time - either proto and


### PR DESCRIPTION
This makes things consistent until we get our vanity import set up. There will be one more sweeping string replace after that.