### PR TITLE
remove duplicated logging interface, remove log package go module

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -4,7 +4,6 @@ go 1.18
 
 require (
 	github.com/ngrok/ngrok-go v0.0.0
-	github.com/ngrok/ngrok-go/log v0.0.0
 	golang.org/x/sync v0.0.0-20220923202941-7f9b1623fab7
 )
 
@@ -21,6 +20,5 @@ require (
 
 replace (
 	github.com/ngrok/ngrok-go => ../
-	github.com/ngrok/ngrok-go/log => ../log
 	github.com/ngrok/ngrok-go/log/log15adapter => ../log/log15adapter
 )

--- a/go.work
+++ b/go.work
@@ -9,14 +9,12 @@ go 1.18
 use (
 	.
 	./examples
-	./log
 	./log/log15adapter
 	./log/pgxadapter
 )
 
 replace (
 	github.com/ngrok/ngrok-go v0.0.0 => ./
-	github.com/ngrok/ngrok-go/log v0.0.0 => ./log
 	github.com/ngrok/ngrok-go/log/log15adapter v0.0.0 => ./log/log15adapter
 	github.com/ngrok/ngrok-go/log/pgxadapter v0.0.0 => ./log/pgxadapter
 )

--- a/go.work.sum
+++ b/go.work.sum
@@ -142,6 +142,7 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20201203163018-be400aefbc4c/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa h1:zuSxTR4o9y82ebqCUJYNGJbGPo6sKVl54f/TVDObg1c=
 golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de h1:5hukYrvBGR8/eNkX5mdUezrA6JiaEZDtJb9Ei+1LlBs=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=

--- a/log/LICENSE.txt
+++ b/log/LICENSE.txt
@@ -1,1 +1,0 @@
-LICENSE.txt

--- a/log/go.mod
+++ b/log/go.mod
@@ -1,3 +1,0 @@
-module github.com/ngrok/ngrok-go/log
-
-go 1.18

--- a/log/log15adapter/go.mod
+++ b/log/log15adapter/go.mod
@@ -2,10 +2,7 @@ module github.com/ngrok/ngrok-go/log/log15adapter
 
 go 1.18
 
-require (
-	github.com/inconshreveable/log15 v0.0.0-20201112154412-8562bdadbbac
-	github.com/ngrok/ngrok-go/log v0.0.0
-)
+require github.com/inconshreveable/log15 v0.0.0-20201112154412-8562bdadbbac
 
 require (
 	github.com/go-stack/stack v1.8.1 // indirect
@@ -13,5 +10,3 @@ require (
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 // indirect
 )
-
-replace github.com/ngrok/ngrok-go/log => ../

--- a/log/pgxadapter/go.mod
+++ b/log/pgxadapter/go.mod
@@ -2,10 +2,7 @@ module github.com/ngrok/ngrok-go/log/pgxadapter
 
 go 1.18
 
-require (
-	github.com/jackc/pgx/v4 v4.17.0
-	github.com/ngrok/ngrok-go/log v0.0.0
-)
+require github.com/jackc/pgx/v4 v4.17.0
 
 require (
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
@@ -18,5 +15,3 @@ require (
 	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa // indirect
 	golang.org/x/text v0.3.7 // indirect
 )
-
-replace github.com/ngrok/ngrok-go/log => ../

--- a/logging.go
+++ b/logging.go
@@ -5,36 +5,11 @@ import (
 	"fmt"
 
 	"github.com/inconshreveable/log15"
+	"github.com/ngrok/ngrok-go/log"
 )
-
-// The level of a log message.
-type LogLevel = int
-
-const (
-	LogLevelTrace = 6
-	LogLevelDebug = 5
-	LogLevelInfo  = 4
-	LogLevelWarn  = 3
-	LogLevelError = 2
-	LogLevelNone  = 1
-)
-
-// Logger defines a logging interface. It is identical to the log.Logger
-// interface in [github.com/ngrok/libngrok-go/log.Logger]. It is duplicated here
-// to avoid having to unconditionally import that submodule. Documentation lives
-// in the [github.com/ngrok/libngrok-go/log.Logger] submodule, as well as
-// adapters for other logging libraries.
-// If you are implementing a logger, you should use the `log` submodule instead,
-// as it also includes things like level formatting functions and doesn't
-// require importing the full `ngrok` module.
-type Logger interface {
-	// Log a message at the given level with data key/value pairs. data may be
-	// nil.
-	Log(context context.Context, level LogLevel, msg string, data map[string]interface{})
-}
 
 type log15Handler struct {
-	Logger
+	log.Logger
 }
 
 // The internals all use log15, so we need to convert the public logging
@@ -44,7 +19,7 @@ type log15Handler struct {
 // by the log15adapter module.
 // Otherwise, a new log15.Logger is constructed and the provided Logger used as
 // its Handler.
-func toLog15(l Logger) log15.Logger {
+func toLog15(l log.Logger) log15.Logger {
 	if logger, ok := l.(log15.Logger); ok {
 		return logger
 	}
@@ -56,22 +31,22 @@ func toLog15(l Logger) log15.Logger {
 }
 
 func (l *log15Handler) Log(r *log15.Record) error {
-	lvl := LogLevelNone
+	lvl := log.LogLevelNone
 	switch r.Lvl {
 	case log15.LvlCrit:
-		lvl = LogLevelError
+		lvl = log.LogLevelError
 	case log15.LvlError:
-		lvl = LogLevelError
+		lvl = log.LogLevelError
 	case log15.LvlWarn:
-		lvl = LogLevelWarn
+		lvl = log.LogLevelWarn
 	case log15.LvlInfo:
-		lvl = LogLevelInfo
+		lvl = log.LogLevelInfo
 	case log15.LvlDebug:
-		lvl = LogLevelDebug
+		lvl = log.LogLevelDebug
 	case log15.LvlDebug + 1:
 		// Also support trace, if someone happens to hack
 		// it in.
-		lvl = LogLevelTrace
+		lvl = log.LogLevelTrace
 	}
 
 	data := make(map[string]interface{}, len(r.Ctx)/2)

--- a/session.go
+++ b/session.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ngrok/ngrok-go/internal/muxado"
 	tunnel_client "github.com/ngrok/ngrok-go/internal/tunnel/client"
 	"github.com/ngrok/ngrok-go/internal/tunnel/proto"
+	"github.com/ngrok/ngrok-go/log"
 	"golang.org/x/net/proxy"
 )
 
@@ -119,7 +120,7 @@ type connectConfig struct {
 	UpdateHandler  ServerCommandHandler
 
 	// The logger for the session to use.
-	Logger Logger
+	Logger log.Logger
 }
 
 // Use the provided opaque metadata string for this session.
@@ -215,7 +216,7 @@ func WithHeartbeatInterval(interval time.Duration) ConnectOption {
 // `pgxadapter`.
 // If the provided `Logger` also implements the `log15.Logger` interface, it
 // will be used directly.
-func WithLogger(logger Logger) ConnectOption {
+func WithLogger(logger log.Logger) ConnectOption {
 	return func(cfg *connectConfig) {
 		cfg.Logger = logger
 	}


### PR DESCRIPTION
The log package was defined as a separate Go module for reasons that seem unncessary. Technically it would let you implement a Logger without needing to import all of the root module's dependencies, but:

1. If you're working with this library, the end application will almost certainly import the root module anyways.
2. The implementing package can still implement the interface without importing any of our package anyways.

The benefit to this change is:

1. The dependency story is simpler to reason about
2. There is no confusing duplication of a Logger interface in both the main package and the subpackage.

Explicitly pulling @euank as a reviewer since this more or less reverts his earlier PR.