### PR TITLE
proto: add ClientType and declare this library as a library

### DIFF
--- a/internal/tunnel/proto/msg.go
+++ b/internal/tunnel/proto/msg.go
@@ -72,7 +72,16 @@ type AuthExtra struct {
 	ConfigVersion   string
 	CustomInterface bool
 	CustomCAs       bool
+
+	ClientType ClientType // The type of client this is. Currently agent and library clients are supported
 }
+
+type ClientType string
+
+const (
+	Agent   ClientType = "agent"
+	Library ClientType = "library"
+)
 
 type Fingerprint struct {
 	M []string

--- a/session.go
+++ b/session.go
@@ -351,7 +351,7 @@ func Connect(ctx context.Context, opts ...ConnectOption) (Session, error) {
 		StopUnsupportedError:    remoteStopErr,
 		UpdateUnsupportedError:  remoteUpdateErr,
 
-		// TODO: More fields here?
+		ClientType: proto.Library,
 	}
 
 	reconnect := func(sess tunnel_client.Session) error {

--- a/session.go
+++ b/session.go
@@ -26,7 +26,7 @@ import (
 )
 
 // The ngrok library version.
-const libraryAgentVersion = "3.0.0-ngrok-go"
+const libraryAgentVersion = "0.0.0"
 
 // The interface implemented by an ngrok session object.
 type Session interface {


### PR DESCRIPTION
Also sets the library version back to 0.0.0. This means we'll have to wait on ngrok-private/ngrok#13827 to merge/deploy, or else it'll get rejected for having too low a version again.