### PR TITLE
Update import path from github -> golang.ngrok.com

### DIFF
--- a/config/basic_auth.go
+++ b/config/basic_auth.go
@@ -1,6 +1,6 @@
 package config
 
-import "github.com/ngrok/ngrok-go/internal/pb_agent"
+import "golang.ngrok.com/ngrok/internal/pb_agent"
 
 // BasicAuth is a set of credentials for basic authentication.
 type basicAuth struct {

--- a/config/cidr_restrictions.go
+++ b/config/cidr_restrictions.go
@@ -3,7 +3,7 @@ package config
 import (
 	"net"
 
-	"github.com/ngrok/ngrok-go/internal/pb_agent"
+	"golang.ngrok.com/ngrok/internal/pb_agent"
 )
 
 // Restrictions placed on the origin of incoming connections to the edge.

--- a/config/http.go
+++ b/config/http.go
@@ -4,8 +4,8 @@ import (
 	"crypto/x509"
 	"net/http"
 
-	"github.com/ngrok/ngrok-go/internal/pb_agent"
-	"github.com/ngrok/ngrok-go/internal/tunnel/proto"
+	"golang.ngrok.com/ngrok/internal/pb_agent"
+	"golang.ngrok.com/ngrok/internal/tunnel/proto"
 )
 
 type HTTPEndpointOption interface {

--- a/config/http_headers.go
+++ b/config/http_headers.go
@@ -3,7 +3,7 @@ package config
 import (
 	"fmt"
 
-	"github.com/ngrok/ngrok-go/internal/pb_agent"
+	"golang.ngrok.com/ngrok/internal/pb_agent"
 )
 
 // HTTP Headers to modify at the ngrok edge.

--- a/config/labeled.go
+++ b/config/labeled.go
@@ -3,7 +3,7 @@ package config
 import (
 	"net/http"
 
-	"github.com/ngrok/ngrok-go/internal/tunnel/proto"
+	"golang.ngrok.com/ngrok/internal/tunnel/proto"
 )
 
 type LabeledTunnelOption interface {

--- a/config/mutual_tls.go
+++ b/config/mutual_tls.go
@@ -4,7 +4,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 
-	"github.com/ngrok/ngrok-go/internal/pb_agent"
+	"golang.ngrok.com/ngrok/internal/pb_agent"
 )
 
 type mutualTLSEndpointOption []*x509.Certificate

--- a/config/oauth.go
+++ b/config/oauth.go
@@ -1,6 +1,6 @@
 package config
 
-import "github.com/ngrok/ngrok-go/internal/pb_agent"
+import "golang.ngrok.com/ngrok/internal/pb_agent"
 
 type OAuthOption func(cfg *oauthOptions)
 

--- a/config/oidc.go
+++ b/config/oidc.go
@@ -1,6 +1,6 @@
 package config
 
-import "github.com/ngrok/ngrok-go/internal/pb_agent"
+import "golang.ngrok.com/ngrok/internal/pb_agent"
 
 type OIDCOption func(cfg *oidcOptions)
 

--- a/config/tcp.go
+++ b/config/tcp.go
@@ -3,7 +3,7 @@ package config
 import (
 	"net/http"
 
-	"github.com/ngrok/ngrok-go/internal/tunnel/proto"
+	"golang.ngrok.com/ngrok/internal/tunnel/proto"
 )
 
 type TCPEndpointOption interface {

--- a/config/tls.go
+++ b/config/tls.go
@@ -4,8 +4,8 @@ import (
 	"crypto/x509"
 	"net/http"
 
-	"github.com/ngrok/ngrok-go/internal/pb_agent"
-	"github.com/ngrok/ngrok-go/internal/tunnel/proto"
+	"golang.ngrok.com/ngrok/internal/pb_agent"
+	"golang.ngrok.com/ngrok/internal/tunnel/proto"
 )
 
 type TLSEndpointOption interface {

--- a/config/webhook_verification.go
+++ b/config/webhook_verification.go
@@ -1,6 +1,6 @@
 package config
 
-import "github.com/ngrok/ngrok-go/internal/pb_agent"
+import "golang.ngrok.com/ngrok/internal/pb_agent"
 
 // Configuration for webhook verification.
 type webhookVerification struct {

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,9 +1,9 @@
-module github.com/ngrok/ngrok-go/examples
+module golang.ngrok.com/ngrok/examples
 
 go 1.18
 
 require (
-	github.com/ngrok/ngrok-go v0.0.0
+	golang.ngrok.com/ngrok v0.0.0
 	golang.org/x/sync v0.0.0-20220923202941-7f9b1623fab7
 )
 
@@ -19,6 +19,6 @@ require (
 )
 
 replace (
-	github.com/ngrok/ngrok-go => ../
-	github.com/ngrok/ngrok-go/log/log15adapter => ../log/log15adapter
+	golang.ngrok.com/ngrok => ../
+	golang.ngrok.com/ngrok/log/log15adapter => ../log/log15adapter
 )

--- a/examples/http/main.go
+++ b/examples/http/main.go
@@ -8,8 +8,8 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/ngrok/ngrok-go"
-	"github.com/ngrok/ngrok-go/config"
+	"golang.ngrok.com/ngrok"
+	"golang.ngrok.com/ngrok/config"
 )
 
 func main() {

--- a/examples/logging/main.go
+++ b/examples/logging/main.go
@@ -10,9 +10,9 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/ngrok/ngrok-go"
-	"github.com/ngrok/ngrok-go/config"
-	ngrok_log "github.com/ngrok/ngrok-go/log"
+	"golang.ngrok.com/ngrok"
+	"golang.ngrok.com/ngrok/config"
+	ngrok_log "golang.ngrok.com/ngrok/log"
 )
 
 func usage(bin string) {

--- a/examples/ngrok-lite/main.go
+++ b/examples/ngrok-lite/main.go
@@ -10,9 +10,10 @@ import (
 	"net"
 	"os"
 
-	"github.com/ngrok/ngrok-go"
-	"github.com/ngrok/ngrok-go/config"
 	"golang.org/x/sync/errgroup"
+
+	"golang.ngrok.com/ngrok"
+	"golang.ngrok.com/ngrok/config"
 )
 
 func usage(bin string) {

--- a/examples/tcp/main.go
+++ b/examples/tcp/main.go
@@ -9,8 +9,8 @@ import (
 	"log"
 	"net"
 
-	"github.com/ngrok/ngrok-go"
-	"github.com/ngrok/ngrok-go/config"
+	"golang.ngrok.com/ngrok"
+	"golang.ngrok.com/ngrok/config"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ngrok/ngrok-go
+module golang.ngrok.com/ngrok
 
 go 1.18
 

--- a/go.work
+++ b/go.work
@@ -15,7 +15,7 @@ use (
 )
 
 replace (
-	github.com/ngrok/ngrok-go v0.0.0 => ./
-	github.com/ngrok/ngrok-go/log/log15adapter v0.0.0 => ./log/log15adapter
-	github.com/ngrok/ngrok-go/log/pgxadapter v0.0.0 => ./log/pgxadapter
+	golang.ngrok.com/ngrok v0.0.0 => ./
+	golang.ngrok.com/ngrok/log/log15adapter v0.0.0 => ./log/log15adapter
+	golang.ngrok.com/ngrok/log/pgxadapter v0.0.0 => ./log/pgxadapter
 )

--- a/go.work.sum
+++ b/go.work.sum
@@ -28,6 +28,7 @@ go.uber.org/zap v1.13.0 h1:nR6NoDBgAf67s68NhaXbsojM+2gxp3S1hWkHDl27pVU=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de h1:5hukYrvBGR8/eNkX5mdUezrA6JiaEZDtJb9Ei+1LlBs=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee h1:WG0RUwxtNT4qqaXX3DPA8zHFNm/D9xaBpxzHt1WcA/E=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/tools v0.0.0-20200103221440-774c71fcf114 h1:DnSr2mCsxyCE6ZgIkmcWUQY2R5cH/6wL7eIxEmQOMSE=
 gopkg.in/errgo.v2 v2.1.0 h1:0vLT13EuvQ0hNvakwLuFZ/jYrLp5F3kcWHXdRggjCE8=
 gopkg.in/inconshreveable/log15.v2 v2.0.0-20180818164646-67afb5ed74ec h1:RlWgLqCMMIYYEVcAR5MDsuHlVkaIPDAF+5Dehzg8L5A=

--- a/internal/muxado/config.go
+++ b/internal/muxado/config.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"sync"
 
-	"github.com/ngrok/ngrok-go/internal/muxado/frame"
+	"golang.ngrok.com/ngrok/internal/muxado/frame"
 )
 
 var zeroConfig Config

--- a/internal/muxado/errors.go
+++ b/internal/muxado/errors.go
@@ -3,7 +3,7 @@ package muxado
 import (
 	"errors"
 
-	"github.com/ngrok/ngrok-go/internal/muxado/frame"
+	"golang.ngrok.com/ngrok/internal/muxado/frame"
 )
 
 // ErrorCode is a 32-bit integer indicating the type of an error condition

--- a/internal/muxado/heartbeat.go
+++ b/internal/muxado/heartbeat.go
@@ -16,11 +16,11 @@ const (
 )
 
 type HeartbeatSession interface {
-        TypedStreamSession
-        Beat() time.Duration
-        Start()
-        SetInterval(d time.Duration)
-        SetTolerance(d time.Duration)
+	TypedStreamSession
+	Beat() time.Duration
+	Start()
+	SetInterval(d time.Duration)
+	SetTolerance(d time.Duration)
 }
 
 type HeartbeatConfig struct {

--- a/internal/muxado/session.go
+++ b/internal/muxado/session.go
@@ -9,7 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/ngrok/ngrok-go/internal/muxado/frame"
+	"golang.ngrok.com/ngrok/internal/muxado/frame"
 )
 
 // private interface for Sessions to call Streams

--- a/internal/muxado/session_test.go
+++ b/internal/muxado/session_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ngrok/ngrok-go/internal/muxado/frame"
+	"golang.ngrok.com/ngrok/internal/muxado/frame"
 )
 
 func newFakeStream(sess sessionPrivate, id frame.StreamId, windowSize uint32, fin bool, init bool) streamPrivate {

--- a/internal/muxado/stream.go
+++ b/internal/muxado/stream.go
@@ -9,7 +9,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/ngrok/ngrok-go/internal/muxado/frame"
+	"golang.ngrok.com/ngrok/internal/muxado/frame"
 )
 
 var (

--- a/internal/muxado/stream_map.go
+++ b/internal/muxado/stream_map.go
@@ -3,7 +3,7 @@ package muxado
 import (
 	"sync"
 
-	"github.com/ngrok/ngrok-go/internal/muxado/frame"
+	"golang.ngrok.com/ngrok/internal/muxado/frame"
 )
 
 const (

--- a/internal/muxado/stream_test.go
+++ b/internal/muxado/stream_test.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/ngrok/ngrok-go/internal/muxado/frame"
+	"golang.ngrok.com/ngrok/internal/muxado/frame"
 )
 
 func TestCloseWrite(t *testing.T) {

--- a/internal/pb_agent/middleware.pb.go
+++ b/internal/pb_agent/middleware.pb.go
@@ -7,10 +7,11 @@
 package pb_agent
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (

--- a/internal/tunnel/client/raw_session.go
+++ b/internal/tunnel/client/raw_session.go
@@ -9,9 +9,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ngrok/ngrok-go/internal/muxado"
-	"github.com/ngrok/ngrok-go/internal/tunnel/netx"
-	"github.com/ngrok/ngrok-go/internal/tunnel/proto"
+	"golang.ngrok.com/ngrok/internal/muxado"
+	"golang.ngrok.com/ngrok/internal/tunnel/netx"
+	"golang.ngrok.com/ngrok/internal/tunnel/proto"
 
 	log "github.com/inconshreveable/log15"
 	logext "github.com/inconshreveable/log15/ext"

--- a/internal/tunnel/client/raw_session_test.go
+++ b/internal/tunnel/client/raw_session_test.go
@@ -4,7 +4,8 @@ import (
 	"testing"
 
 	"github.com/inconshreveable/log15"
-	"github.com/ngrok/ngrok-go/internal/muxado"
+
+	"golang.ngrok.com/ngrok/internal/muxado"
 )
 
 type dummyStream struct{}

--- a/internal/tunnel/client/reconnecting.go
+++ b/internal/tunnel/client/reconnecting.go
@@ -8,8 +8,9 @@ import (
 
 	log "github.com/inconshreveable/log15"
 	"github.com/jpillora/backoff"
-	"github.com/ngrok/ngrok-go/internal/tunnel/netx"
-	"github.com/ngrok/ngrok-go/internal/tunnel/proto"
+
+	"golang.ngrok.com/ngrok/internal/tunnel/netx"
+	"golang.ngrok.com/ngrok/internal/tunnel/proto"
 )
 
 var ErrSessionNotReady = errors.New("an ngrok tunnel session has not yet been established")

--- a/internal/tunnel/client/session.go
+++ b/internal/tunnel/client/session.go
@@ -10,11 +10,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ngrok/ngrok-go/internal/tunnel/netx"
-	"github.com/ngrok/ngrok-go/internal/tunnel/proto"
+	"golang.ngrok.com/ngrok/internal/tunnel/netx"
+	"golang.ngrok.com/ngrok/internal/tunnel/proto"
 
 	log "github.com/inconshreveable/log15"
-	muxado "github.com/ngrok/ngrok-go/internal/muxado"
+
+	muxado "golang.ngrok.com/ngrok/internal/muxado"
 )
 
 // Session is a higher-level client session interface. You will almost always prefer this over

--- a/internal/tunnel/client/tunnel.go
+++ b/internal/tunnel/client/tunnel.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"sync/atomic"
 
-	"github.com/ngrok/ngrok-go/internal/tunnel/proto"
+	"golang.ngrok.com/ngrok/internal/tunnel/proto"
 )
 
 type Tunnel interface {

--- a/internal/tunnel/proto/msg.go
+++ b/internal/tunnel/proto/msg.go
@@ -1,9 +1,9 @@
 package proto
 
 import (
-	"github.com/ngrok/ngrok-go/internal/pb_agent"
+	"golang.ngrok.com/ngrok/internal/pb_agent"
 
-	"github.com/ngrok/ngrok-go/internal/muxado"
+	"golang.ngrok.com/ngrok/internal/muxado"
 )
 
 type ReqType muxado.StreamType

--- a/log/log15/adapter.go
+++ b/log/log15/adapter.go
@@ -1,6 +1,6 @@
 // Package log15 provides a logger that writes to a
 // github.com/inconshreveable/log15.Logger and implements the
-// github.com/ngrok/ngrok-go/log.Logger interface.
+// golang.ngrok.com/ngrok/log.Logger interface.
 //
 // Adapted from the github.com/jackc/pgx log15 adapter.
 package log15
@@ -13,7 +13,7 @@ import (
 
 type LogLevel = int
 
-// Log level constants matching the ones in github.com/ngrok/ngrok-go/log
+// Log level constants matching the ones in golang.ngrok.com/ngrok/log
 const (
 	LogLevelTrace = 6
 	LogLevelDebug = 5

--- a/log/log15/go.mod
+++ b/log/log15/go.mod
@@ -1,4 +1,4 @@
-module github.com/ngrok/ngrok-go/log/log15
+module golang.ngrok.com/ngrok/log/log15
 
 go 1.18
 

--- a/log/logrus/adapter.go
+++ b/log/logrus/adapter.go
@@ -1,6 +1,6 @@
 // Package logrus provides a logger that writes to a
 // github.com/sirupsen/logrus.Logger and implements the
-// github.com/ngrok/ngrok-go/log.Logger interface.
+// golang.ngrok.com/ngrok/log.Logger interface.
 //
 // Adapted from the github.com/jackc/pgx logrus adapter.
 package logrus
@@ -13,7 +13,7 @@ import (
 
 type LogLevel = int
 
-// Log level constants matching the ones in github.com/ngrok/ngrok-go/log
+// Log level constants matching the ones in golang.ngrok.com/ngrok/log
 const (
 	LogLevelTrace = 6
 	LogLevelDebug = 5

--- a/log/logrus/go.mod
+++ b/log/logrus/go.mod
@@ -1,4 +1,4 @@
-module github.com/ngrok/ngrok-go/log/logrus
+module golang.ngrok.com/ngrok/log/logrus
 
 go 1.18
 

--- a/log/zap/adapter.go
+++ b/log/zap/adapter.go
@@ -1,5 +1,5 @@
 // Package zap provides a logger that writes to a go.uber.org/zap.Logger and
-// implements the github.com/ngrok/ngrok-go/log.Logger interface.
+// implements the golang.ngrok.com/ngrok/log.Logger interface.
 //
 // Adapted from the github.com/jackc/pgx zap adapter.
 package zap
@@ -13,7 +13,7 @@ import (
 
 type LogLevel = int
 
-// Log level constants matching the ones in github.com/ngrok/ngrok-go/log
+// Log level constants matching the ones in golang.ngrok.com/ngrok/log
 const (
 	LogLevelTrace = 6
 	LogLevelDebug = 5

--- a/log/zap/go.mod
+++ b/log/zap/go.mod
@@ -1,4 +1,4 @@
-module github.com/ngrok/ngrok-go/log/zap
+module golang.ngrok.com/ngrok/log/zap
 
 go 1.18
 

--- a/logging.go
+++ b/logging.go
@@ -5,7 +5,8 @@ import (
 	"fmt"
 
 	"github.com/inconshreveable/log15"
-	"github.com/ngrok/ngrok-go/log"
+
+	"golang.ngrok.com/ngrok/log"
 )
 
 type log15Handler struct {

--- a/online_test.go
+++ b/online_test.go
@@ -15,9 +15,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ngrok/ngrok-go/config"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/websocket"
+
+	"golang.ngrok.com/ngrok/config"
 )
 
 func skipUnless(t *testing.T, varname string, message ...any) {

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -8,4 +8,4 @@ coverage: test
 
 docs:
 	pkgsite >/dev/null 2>&1 & \
-		xdg-open http://127.0.0.1:8080/github.com/ngrok/ngrok-go
+		xdg-open http://127.0.0.1:8080/golang.ngrok.com/ngrok

--- a/session.go
+++ b/session.go
@@ -18,12 +18,13 @@ import (
 	"unsafe"
 
 	"github.com/inconshreveable/log15"
-	"github.com/ngrok/ngrok-go/config"
-	"github.com/ngrok/ngrok-go/internal/muxado"
-	tunnel_client "github.com/ngrok/ngrok-go/internal/tunnel/client"
-	"github.com/ngrok/ngrok-go/internal/tunnel/proto"
-	"github.com/ngrok/ngrok-go/log"
 	"golang.org/x/net/proxy"
+
+	"golang.ngrok.com/ngrok/config"
+	"golang.ngrok.com/ngrok/internal/muxado"
+	tunnel_client "golang.ngrok.com/ngrok/internal/tunnel/client"
+	"golang.ngrok.com/ngrok/internal/tunnel/proto"
+	"golang.ngrok.com/ngrok/log"
 )
 
 // The ngrok library version.

--- a/tunnel.go
+++ b/tunnel.go
@@ -5,8 +5,8 @@ import (
 	"net"
 	"time"
 
-	"github.com/ngrok/ngrok-go/config"
-	tunnel_client "github.com/ngrok/ngrok-go/internal/tunnel/client"
+	"golang.ngrok.com/ngrok/config"
+	tunnel_client "golang.ngrok.com/ngrok/internal/tunnel/client"
 )
 
 // An ngrok tunnel.

--- a/tunnel_config.go
+++ b/tunnel_config.go
@@ -1,6 +1,6 @@
 package ngrok
 
-import "github.com/ngrok/ngrok-go/internal/tunnel/proto"
+import "golang.ngrok.com/ngrok/internal/tunnel/proto"
 
 type tunnelConfigPrivate interface {
 	ForwardsTo() string


### PR DESCRIPTION
This allows us to have `ngrok-go` in the github URL, without having the slightly confusing import basename vs package name mismatch.

As-is, this change depends on an internal change for that URL to go public, but with some local dns hackery, I can see it work via:

```
$ GOPRIVATE=golang.ngrok.com GOPROXY=direct GOINSECURE=golang.ngrok.com go get -v -u golang.ngrok.com/ngrok@euan/update-import-path
```

being able to succeed (depending on me having setup my local dns to point `golang.ngrok.com` at an internal testing domain)