### PR TITLE
proto: deprecate/remove hostname and subdomain

### DIFF
--- a/config/domain_test.go
+++ b/config/domain_test.go
@@ -40,9 +40,9 @@ func testDomain[T tunnelConfigPrivate, O any, OT any](t *testing.T,
 
 func TestDomain(t *testing.T) {
 	testDomain[httpOptions](t, HTTPEndpoint, func(opts *proto.HTTPEndpoint) string {
-		return opts.Hostname
+		return opts.Domain
 	})
 	testDomain[tlsOptions](t, TLSEndpoint, func(opts *proto.TLSEndpoint) string {
-		return opts.Hostname
+		return opts.Domain
 	})
 }

--- a/config/http.go
+++ b/config/http.go
@@ -73,7 +73,7 @@ type httpOptions struct {
 
 func (cfg *httpOptions) toProtoConfig() *proto.HTTPEndpoint {
 	opts := &proto.HTTPEndpoint{
-		Hostname: cfg.Domain,
+		Domain: cfg.Domain,
 	}
 
 	if cfg.Compression {

--- a/config/tls.go
+++ b/config/tls.go
@@ -50,7 +50,7 @@ type tlsOptions struct {
 
 func (cfg *tlsOptions) toProtoConfig() *proto.TLSEndpoint {
 	opts := &proto.TLSEndpoint{
-		Hostname:   cfg.Domain,
+		Domain:     cfg.Domain,
 		ProxyProto: proto.ProxyProto(cfg.ProxyProto),
 	}
 

--- a/internal/tunnel/proto/msg.go
+++ b/internal/tunnel/proto/msg.go
@@ -188,9 +188,8 @@ func ParseProxyProto(proxyProto string) (ProxyProto, bool) {
 }
 
 type HTTPEndpoint struct {
-	Hostname          string // public hostname of the bind
+	Domain            string
 	Auth              string
-	Subdomain         string
 	HostHeaderRewrite bool   // true if the request's host header is being rewritten
 	LocalURLScheme    string // scheme of the local forward
 	ProxyProto
@@ -218,8 +217,7 @@ type TCPEndpoint struct {
 }
 
 type TLSEndpoint struct {
-	Hostname  string // public hostname of the bind
-	Subdomain string
+	Domain string
 	ProxyProto
 	MutualTLSAtAgent bool
 

--- a/online_test.go
+++ b/online_test.go
@@ -400,27 +400,6 @@ func TestProxyProto(t *testing.T) {
 	}
 }
 
-func TestHostname(t *testing.T) {
-	paidTest(t)
-	ctx := context.Background()
-
-	tun, exited := serveHTTP(ctx, t, nil,
-		config.HTTPEndpoint(config.WithDomain("foo.robsonchase.com")),
-		helloHandler,
-	)
-	require.Equal(t, "https://foo.robsonchase.com", tun.URL())
-
-	resp, err := http.Get(tun.URL())
-	require.NoError(t, err)
-
-	content, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-	require.Equal(t, "Hello, world!\n", string(content))
-
-	require.NoError(t, tun.CloseWithContext(ctx))
-	require.Error(t, <-exited)
-}
-
 func TestSubdomain(t *testing.T) {
 	paidTest(t)
 	ctx := context.Background()


### PR DESCRIPTION
Follow-up from #46.

Removes the deprecated `Hostname` and `Subdomain` fields for the new and improved `Domain` field.

No externally-visible API changes.