### PR TITLE
sec: make sure we don't log the authtoken in plaintext by accident

### DIFF
--- a/internal/pb/middleware.pb.go
+++ b/internal/pb/middleware.pb.go
@@ -155,6 +155,243 @@ func (x *MiddlewareConfiguration) GetOidc() *MiddlewareConfiguration_OIDC {
 	return nil
 }
 
+type HTTPMiddleware struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Compression           *MiddlewareConfiguration_Compression           `protobuf:"bytes,1,opt,name=compression,proto3" json:"compression,omitempty"`
+	CircuitBreaker        *MiddlewareConfiguration_CircuitBreaker        `protobuf:"bytes,2,opt,name=circuit_breaker,json=circuitBreaker,proto3" json:"circuit_breaker,omitempty"`
+	IpRestriction         *MiddlewareConfiguration_IPRestriction         `protobuf:"bytes,3,opt,name=ip_restriction,json=ipRestriction,proto3" json:"ip_restriction,omitempty"`
+	BasicAuth             *MiddlewareConfiguration_BasicAuth             `protobuf:"bytes,4,opt,name=basic_auth,json=basicAuth,proto3" json:"basic_auth,omitempty"`
+	Oauth                 *MiddlewareConfiguration_OAuth                 `protobuf:"bytes,5,opt,name=oauth,proto3" json:"oauth,omitempty"`
+	Oidc                  *MiddlewareConfiguration_OIDC                  `protobuf:"bytes,6,opt,name=oidc,proto3" json:"oidc,omitempty"`
+	WebhookVerification   *MiddlewareConfiguration_WebhookVerification   `protobuf:"bytes,7,opt,name=webhook_verification,json=webhookVerification,proto3" json:"webhook_verification,omitempty"`
+	MutualTls             *MiddlewareConfiguration_MutualTLS             `protobuf:"bytes,8,opt,name=mutual_tls,json=mutualTls,proto3" json:"mutual_tls,omitempty"`
+	RequestHeaders        *MiddlewareConfiguration_Headers               `protobuf:"bytes,9,opt,name=request_headers,json=requestHeaders,proto3" json:"request_headers,omitempty"`
+	ResponseHeaders       *MiddlewareConfiguration_Headers               `protobuf:"bytes,10,opt,name=response_headers,json=responseHeaders,proto3" json:"response_headers,omitempty"`
+	WebsocketTcpConverter *MiddlewareConfiguration_WebsocketTCPConverter `protobuf:"bytes,11,opt,name=websocket_tcp_converter,json=websocketTcpConverter,proto3" json:"websocket_tcp_converter,omitempty"`
+}
+
+func (x *HTTPMiddleware) Reset() {
+	*x = HTTPMiddleware{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_internal_pb_middleware_proto_msgTypes[1]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *HTTPMiddleware) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*HTTPMiddleware) ProtoMessage() {}
+
+func (x *HTTPMiddleware) ProtoReflect() protoreflect.Message {
+	mi := &file_internal_pb_middleware_proto_msgTypes[1]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use HTTPMiddleware.ProtoReflect.Descriptor instead.
+func (*HTTPMiddleware) Descriptor() ([]byte, []int) {
+	return file_internal_pb_middleware_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *HTTPMiddleware) GetCompression() *MiddlewareConfiguration_Compression {
+	if x != nil {
+		return x.Compression
+	}
+	return nil
+}
+
+func (x *HTTPMiddleware) GetCircuitBreaker() *MiddlewareConfiguration_CircuitBreaker {
+	if x != nil {
+		return x.CircuitBreaker
+	}
+	return nil
+}
+
+func (x *HTTPMiddleware) GetIpRestriction() *MiddlewareConfiguration_IPRestriction {
+	if x != nil {
+		return x.IpRestriction
+	}
+	return nil
+}
+
+func (x *HTTPMiddleware) GetBasicAuth() *MiddlewareConfiguration_BasicAuth {
+	if x != nil {
+		return x.BasicAuth
+	}
+	return nil
+}
+
+func (x *HTTPMiddleware) GetOauth() *MiddlewareConfiguration_OAuth {
+	if x != nil {
+		return x.Oauth
+	}
+	return nil
+}
+
+func (x *HTTPMiddleware) GetOidc() *MiddlewareConfiguration_OIDC {
+	if x != nil {
+		return x.Oidc
+	}
+	return nil
+}
+
+func (x *HTTPMiddleware) GetWebhookVerification() *MiddlewareConfiguration_WebhookVerification {
+	if x != nil {
+		return x.WebhookVerification
+	}
+	return nil
+}
+
+func (x *HTTPMiddleware) GetMutualTls() *MiddlewareConfiguration_MutualTLS {
+	if x != nil {
+		return x.MutualTls
+	}
+	return nil
+}
+
+func (x *HTTPMiddleware) GetRequestHeaders() *MiddlewareConfiguration_Headers {
+	if x != nil {
+		return x.RequestHeaders
+	}
+	return nil
+}
+
+func (x *HTTPMiddleware) GetResponseHeaders() *MiddlewareConfiguration_Headers {
+	if x != nil {
+		return x.ResponseHeaders
+	}
+	return nil
+}
+
+func (x *HTTPMiddleware) GetWebsocketTcpConverter() *MiddlewareConfiguration_WebsocketTCPConverter {
+	if x != nil {
+		return x.WebsocketTcpConverter
+	}
+	return nil
+}
+
+type TCPMiddleware struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	IpRestriction *MiddlewareConfiguration_IPRestriction `protobuf:"bytes,1,opt,name=ip_restriction,json=ipRestriction,proto3" json:"ip_restriction,omitempty"`
+}
+
+func (x *TCPMiddleware) Reset() {
+	*x = TCPMiddleware{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_internal_pb_middleware_proto_msgTypes[2]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *TCPMiddleware) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TCPMiddleware) ProtoMessage() {}
+
+func (x *TCPMiddleware) ProtoReflect() protoreflect.Message {
+	mi := &file_internal_pb_middleware_proto_msgTypes[2]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TCPMiddleware.ProtoReflect.Descriptor instead.
+func (*TCPMiddleware) Descriptor() ([]byte, []int) {
+	return file_internal_pb_middleware_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *TCPMiddleware) GetIpRestriction() *MiddlewareConfiguration_IPRestriction {
+	if x != nil {
+		return x.IpRestriction
+	}
+	return nil
+}
+
+type TLSMiddleware struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	MutualTls      *MiddlewareConfiguration_MutualTLS      `protobuf:"bytes,1,opt,name=mutual_tls,json=mutualTls,proto3" json:"mutual_tls,omitempty"`
+	TlsTermination *MiddlewareConfiguration_TLSTermination `protobuf:"bytes,2,opt,name=tls_termination,json=tlsTermination,proto3" json:"tls_termination,omitempty"`
+	IpRestriction  *MiddlewareConfiguration_IPRestriction  `protobuf:"bytes,3,opt,name=ip_restriction,json=ipRestriction,proto3" json:"ip_restriction,omitempty"`
+}
+
+func (x *TLSMiddleware) Reset() {
+	*x = TLSMiddleware{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_internal_pb_middleware_proto_msgTypes[3]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *TLSMiddleware) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TLSMiddleware) ProtoMessage() {}
+
+func (x *TLSMiddleware) ProtoReflect() protoreflect.Message {
+	mi := &file_internal_pb_middleware_proto_msgTypes[3]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TLSMiddleware.ProtoReflect.Descriptor instead.
+func (*TLSMiddleware) Descriptor() ([]byte, []int) {
+	return file_internal_pb_middleware_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *TLSMiddleware) GetMutualTls() *MiddlewareConfiguration_MutualTLS {
+	if x != nil {
+		return x.MutualTls
+	}
+	return nil
+}
+
+func (x *TLSMiddleware) GetTlsTermination() *MiddlewareConfiguration_TLSTermination {
+	if x != nil {
+		return x.TlsTermination
+	}
+	return nil
+}
+
+func (x *TLSMiddleware) GetIpRestriction() *MiddlewareConfiguration_IPRestriction {
+	if x != nil {
+		return x.IpRestriction
+	}
+	return nil
+}
+
 type MiddlewareConfiguration_Compression struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -164,7 +401,7 @@ type MiddlewareConfiguration_Compression struct {
 func (x *MiddlewareConfiguration_Compression) Reset() {
 	*x = MiddlewareConfiguration_Compression{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_internal_pb_middleware_proto_msgTypes[1]
+		mi := &file_internal_pb_middleware_proto_msgTypes[4]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -177,7 +414,7 @@ func (x *MiddlewareConfiguration_Compression) String() string {
 func (*MiddlewareConfiguration_Compression) ProtoMessage() {}
 
 func (x *MiddlewareConfiguration_Compression) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_pb_middleware_proto_msgTypes[1]
+	mi := &file_internal_pb_middleware_proto_msgTypes[4]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -204,7 +441,7 @@ type MiddlewareConfiguration_CircuitBreaker struct {
 func (x *MiddlewareConfiguration_CircuitBreaker) Reset() {
 	*x = MiddlewareConfiguration_CircuitBreaker{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_internal_pb_middleware_proto_msgTypes[2]
+		mi := &file_internal_pb_middleware_proto_msgTypes[5]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -217,7 +454,7 @@ func (x *MiddlewareConfiguration_CircuitBreaker) String() string {
 func (*MiddlewareConfiguration_CircuitBreaker) ProtoMessage() {}
 
 func (x *MiddlewareConfiguration_CircuitBreaker) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_pb_middleware_proto_msgTypes[2]
+	mi := &file_internal_pb_middleware_proto_msgTypes[5]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -252,7 +489,7 @@ type MiddlewareConfiguration_IPRestriction struct {
 func (x *MiddlewareConfiguration_IPRestriction) Reset() {
 	*x = MiddlewareConfiguration_IPRestriction{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_internal_pb_middleware_proto_msgTypes[3]
+		mi := &file_internal_pb_middleware_proto_msgTypes[6]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -265,7 +502,7 @@ func (x *MiddlewareConfiguration_IPRestriction) String() string {
 func (*MiddlewareConfiguration_IPRestriction) ProtoMessage() {}
 
 func (x *MiddlewareConfiguration_IPRestriction) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_pb_middleware_proto_msgTypes[3]
+	mi := &file_internal_pb_middleware_proto_msgTypes[6]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -306,7 +543,7 @@ type MiddlewareConfiguration_BasicAuth struct {
 func (x *MiddlewareConfiguration_BasicAuth) Reset() {
 	*x = MiddlewareConfiguration_BasicAuth{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_internal_pb_middleware_proto_msgTypes[4]
+		mi := &file_internal_pb_middleware_proto_msgTypes[7]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -319,7 +556,7 @@ func (x *MiddlewareConfiguration_BasicAuth) String() string {
 func (*MiddlewareConfiguration_BasicAuth) ProtoMessage() {}
 
 func (x *MiddlewareConfiguration_BasicAuth) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_pb_middleware_proto_msgTypes[4]
+	mi := &file_internal_pb_middleware_proto_msgTypes[7]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -355,7 +592,7 @@ type MiddlewareConfiguration_BasicAuthCredential struct {
 func (x *MiddlewareConfiguration_BasicAuthCredential) Reset() {
 	*x = MiddlewareConfiguration_BasicAuthCredential{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_internal_pb_middleware_proto_msgTypes[5]
+		mi := &file_internal_pb_middleware_proto_msgTypes[8]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -368,7 +605,7 @@ func (x *MiddlewareConfiguration_BasicAuthCredential) String() string {
 func (*MiddlewareConfiguration_BasicAuthCredential) ProtoMessage() {}
 
 func (x *MiddlewareConfiguration_BasicAuthCredential) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_pb_middleware_proto_msgTypes[5]
+	mi := &file_internal_pb_middleware_proto_msgTypes[8]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -422,7 +659,7 @@ type MiddlewareConfiguration_OAuth struct {
 func (x *MiddlewareConfiguration_OAuth) Reset() {
 	*x = MiddlewareConfiguration_OAuth{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_internal_pb_middleware_proto_msgTypes[6]
+		mi := &file_internal_pb_middleware_proto_msgTypes[9]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -435,7 +672,7 @@ func (x *MiddlewareConfiguration_OAuth) String() string {
 func (*MiddlewareConfiguration_OAuth) ProtoMessage() {}
 
 func (x *MiddlewareConfiguration_OAuth) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_pb_middleware_proto_msgTypes[6]
+	mi := &file_internal_pb_middleware_proto_msgTypes[9]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -513,7 +750,7 @@ type MiddlewareConfiguration_WebhookVerification struct {
 func (x *MiddlewareConfiguration_WebhookVerification) Reset() {
 	*x = MiddlewareConfiguration_WebhookVerification{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_internal_pb_middleware_proto_msgTypes[7]
+		mi := &file_internal_pb_middleware_proto_msgTypes[10]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -526,7 +763,7 @@ func (x *MiddlewareConfiguration_WebhookVerification) String() string {
 func (*MiddlewareConfiguration_WebhookVerification) ProtoMessage() {}
 
 func (x *MiddlewareConfiguration_WebhookVerification) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_pb_middleware_proto_msgTypes[7]
+	mi := &file_internal_pb_middleware_proto_msgTypes[10]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -574,7 +811,7 @@ type MiddlewareConfiguration_MutualTLS struct {
 func (x *MiddlewareConfiguration_MutualTLS) Reset() {
 	*x = MiddlewareConfiguration_MutualTLS{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_internal_pb_middleware_proto_msgTypes[8]
+		mi := &file_internal_pb_middleware_proto_msgTypes[11]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -587,7 +824,7 @@ func (x *MiddlewareConfiguration_MutualTLS) String() string {
 func (*MiddlewareConfiguration_MutualTLS) ProtoMessage() {}
 
 func (x *MiddlewareConfiguration_MutualTLS) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_pb_middleware_proto_msgTypes[8]
+	mi := &file_internal_pb_middleware_proto_msgTypes[11]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -623,7 +860,7 @@ type MiddlewareConfiguration_TLSTermination struct {
 func (x *MiddlewareConfiguration_TLSTermination) Reset() {
 	*x = MiddlewareConfiguration_TLSTermination{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_internal_pb_middleware_proto_msgTypes[9]
+		mi := &file_internal_pb_middleware_proto_msgTypes[12]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -636,7 +873,7 @@ func (x *MiddlewareConfiguration_TLSTermination) String() string {
 func (*MiddlewareConfiguration_TLSTermination) ProtoMessage() {}
 
 func (x *MiddlewareConfiguration_TLSTermination) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_pb_middleware_proto_msgTypes[9]
+	mi := &file_internal_pb_middleware_proto_msgTypes[12]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -686,7 +923,7 @@ type MiddlewareConfiguration_Headers struct {
 func (x *MiddlewareConfiguration_Headers) Reset() {
 	*x = MiddlewareConfiguration_Headers{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_internal_pb_middleware_proto_msgTypes[10]
+		mi := &file_internal_pb_middleware_proto_msgTypes[13]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -699,7 +936,7 @@ func (x *MiddlewareConfiguration_Headers) String() string {
 func (*MiddlewareConfiguration_Headers) ProtoMessage() {}
 
 func (x *MiddlewareConfiguration_Headers) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_pb_middleware_proto_msgTypes[10]
+	mi := &file_internal_pb_middleware_proto_msgTypes[13]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -745,7 +982,7 @@ type MiddlewareConfiguration_WebsocketTCPConverter struct {
 func (x *MiddlewareConfiguration_WebsocketTCPConverter) Reset() {
 	*x = MiddlewareConfiguration_WebsocketTCPConverter{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_internal_pb_middleware_proto_msgTypes[11]
+		mi := &file_internal_pb_middleware_proto_msgTypes[14]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -758,7 +995,7 @@ func (x *MiddlewareConfiguration_WebsocketTCPConverter) String() string {
 func (*MiddlewareConfiguration_WebsocketTCPConverter) ProtoMessage() {}
 
 func (x *MiddlewareConfiguration_WebsocketTCPConverter) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_pb_middleware_proto_msgTypes[11]
+	mi := &file_internal_pb_middleware_proto_msgTypes[14]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -791,7 +1028,7 @@ type MiddlewareConfiguration_OIDC struct {
 func (x *MiddlewareConfiguration_OIDC) Reset() {
 	*x = MiddlewareConfiguration_OIDC{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_internal_pb_middleware_proto_msgTypes[12]
+		mi := &file_internal_pb_middleware_proto_msgTypes[15]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -804,7 +1041,7 @@ func (x *MiddlewareConfiguration_OIDC) String() string {
 func (*MiddlewareConfiguration_OIDC) ProtoMessage() {}
 
 func (x *MiddlewareConfiguration_OIDC) ProtoReflect() protoreflect.Message {
-	mi := &file_internal_pb_middleware_proto_msgTypes[12]
+	mi := &file_internal_pb_middleware_proto_msgTypes[15]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1031,10 +1268,98 @@ var file_internal_pb_middleware_proto_rawDesc = []byte{
 	0x77, 0x5f, 0x64, 0x6f, 0x6d, 0x61, 0x69, 0x6e, 0x73, 0x18, 0x06, 0x20, 0x03, 0x28, 0x09, 0x52,
 	0x0c, 0x61, 0x6c, 0x6c, 0x6f, 0x77, 0x44, 0x6f, 0x6d, 0x61, 0x69, 0x6e, 0x73, 0x12, 0x16, 0x0a,
 	0x06, 0x73, 0x63, 0x6f, 0x70, 0x65, 0x73, 0x18, 0x07, 0x20, 0x03, 0x28, 0x09, 0x52, 0x06, 0x73,
-	0x63, 0x6f, 0x70, 0x65, 0x73, 0x42, 0x24, 0x5a, 0x22, 0x67, 0x6f, 0x6c, 0x61, 0x6e, 0x67, 0x2e,
-	0x6e, 0x67, 0x72, 0x6f, 0x6b, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x6e, 0x67, 0x72, 0x6f, 0x6b, 0x2f,
-	0x69, 0x6e, 0x74, 0x65, 0x72, 0x6e, 0x61, 0x6c, 0x2f, 0x70, 0x62, 0x62, 0x06, 0x70, 0x72, 0x6f,
-	0x74, 0x6f, 0x33,
+	0x63, 0x6f, 0x70, 0x65, 0x73, 0x22, 0xee, 0x07, 0x0a, 0x0e, 0x48, 0x54, 0x54, 0x50, 0x4d, 0x69,
+	0x64, 0x64, 0x6c, 0x65, 0x77, 0x61, 0x72, 0x65, 0x12, 0x55, 0x0a, 0x0b, 0x63, 0x6f, 0x6d, 0x70,
+	0x72, 0x65, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x33, 0x2e,
+	0x61, 0x67, 0x65, 0x6e, 0x74, 0x5f, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x6e, 0x61, 0x6c, 0x2e, 0x4d,
+	0x69, 0x64, 0x64, 0x6c, 0x65, 0x77, 0x61, 0x72, 0x65, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x75,
+	0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x2e, 0x43, 0x6f, 0x6d, 0x70, 0x72, 0x65, 0x73, 0x73, 0x69,
+	0x6f, 0x6e, 0x52, 0x0b, 0x63, 0x6f, 0x6d, 0x70, 0x72, 0x65, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x12,
+	0x5f, 0x0a, 0x0f, 0x63, 0x69, 0x72, 0x63, 0x75, 0x69, 0x74, 0x5f, 0x62, 0x72, 0x65, 0x61, 0x6b,
+	0x65, 0x72, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x36, 0x2e, 0x61, 0x67, 0x65, 0x6e, 0x74,
+	0x5f, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x6e, 0x61, 0x6c, 0x2e, 0x4d, 0x69, 0x64, 0x64, 0x6c, 0x65,
+	0x77, 0x61, 0x72, 0x65, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x75, 0x72, 0x61, 0x74, 0x69, 0x6f,
+	0x6e, 0x2e, 0x43, 0x69, 0x72, 0x63, 0x75, 0x69, 0x74, 0x42, 0x72, 0x65, 0x61, 0x6b, 0x65, 0x72,
+	0x52, 0x0e, 0x63, 0x69, 0x72, 0x63, 0x75, 0x69, 0x74, 0x42, 0x72, 0x65, 0x61, 0x6b, 0x65, 0x72,
+	0x12, 0x5c, 0x0a, 0x0e, 0x69, 0x70, 0x5f, 0x72, 0x65, 0x73, 0x74, 0x72, 0x69, 0x63, 0x74, 0x69,
+	0x6f, 0x6e, 0x18, 0x03, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x35, 0x2e, 0x61, 0x67, 0x65, 0x6e, 0x74,
+	0x5f, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x6e, 0x61, 0x6c, 0x2e, 0x4d, 0x69, 0x64, 0x64, 0x6c, 0x65,
+	0x77, 0x61, 0x72, 0x65, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x75, 0x72, 0x61, 0x74, 0x69, 0x6f,
+	0x6e, 0x2e, 0x49, 0x50, 0x52, 0x65, 0x73, 0x74, 0x72, 0x69, 0x63, 0x74, 0x69, 0x6f, 0x6e, 0x52,
+	0x0d, 0x69, 0x70, 0x52, 0x65, 0x73, 0x74, 0x72, 0x69, 0x63, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x50,
+	0x0a, 0x0a, 0x62, 0x61, 0x73, 0x69, 0x63, 0x5f, 0x61, 0x75, 0x74, 0x68, 0x18, 0x04, 0x20, 0x01,
+	0x28, 0x0b, 0x32, 0x31, 0x2e, 0x61, 0x67, 0x65, 0x6e, 0x74, 0x5f, 0x69, 0x6e, 0x74, 0x65, 0x72,
+	0x6e, 0x61, 0x6c, 0x2e, 0x4d, 0x69, 0x64, 0x64, 0x6c, 0x65, 0x77, 0x61, 0x72, 0x65, 0x43, 0x6f,
+	0x6e, 0x66, 0x69, 0x67, 0x75, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x2e, 0x42, 0x61, 0x73, 0x69,
+	0x63, 0x41, 0x75, 0x74, 0x68, 0x52, 0x09, 0x62, 0x61, 0x73, 0x69, 0x63, 0x41, 0x75, 0x74, 0x68,
+	0x12, 0x43, 0x0a, 0x05, 0x6f, 0x61, 0x75, 0x74, 0x68, 0x18, 0x05, 0x20, 0x01, 0x28, 0x0b, 0x32,
+	0x2d, 0x2e, 0x61, 0x67, 0x65, 0x6e, 0x74, 0x5f, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x6e, 0x61, 0x6c,
+	0x2e, 0x4d, 0x69, 0x64, 0x64, 0x6c, 0x65, 0x77, 0x61, 0x72, 0x65, 0x43, 0x6f, 0x6e, 0x66, 0x69,
+	0x67, 0x75, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x2e, 0x4f, 0x41, 0x75, 0x74, 0x68, 0x52, 0x05,
+	0x6f, 0x61, 0x75, 0x74, 0x68, 0x12, 0x40, 0x0a, 0x04, 0x6f, 0x69, 0x64, 0x63, 0x18, 0x06, 0x20,
+	0x01, 0x28, 0x0b, 0x32, 0x2c, 0x2e, 0x61, 0x67, 0x65, 0x6e, 0x74, 0x5f, 0x69, 0x6e, 0x74, 0x65,
+	0x72, 0x6e, 0x61, 0x6c, 0x2e, 0x4d, 0x69, 0x64, 0x64, 0x6c, 0x65, 0x77, 0x61, 0x72, 0x65, 0x43,
+	0x6f, 0x6e, 0x66, 0x69, 0x67, 0x75, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x2e, 0x4f, 0x49, 0x44,
+	0x43, 0x52, 0x04, 0x6f, 0x69, 0x64, 0x63, 0x12, 0x6e, 0x0a, 0x14, 0x77, 0x65, 0x62, 0x68, 0x6f,
+	0x6f, 0x6b, 0x5f, 0x76, 0x65, 0x72, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x18,
+	0x07, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x3b, 0x2e, 0x61, 0x67, 0x65, 0x6e, 0x74, 0x5f, 0x69, 0x6e,
+	0x74, 0x65, 0x72, 0x6e, 0x61, 0x6c, 0x2e, 0x4d, 0x69, 0x64, 0x64, 0x6c, 0x65, 0x77, 0x61, 0x72,
+	0x65, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x75, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x2e, 0x57,
+	0x65, 0x62, 0x68, 0x6f, 0x6f, 0x6b, 0x56, 0x65, 0x72, 0x69, 0x66, 0x69, 0x63, 0x61, 0x74, 0x69,
+	0x6f, 0x6e, 0x52, 0x13, 0x77, 0x65, 0x62, 0x68, 0x6f, 0x6f, 0x6b, 0x56, 0x65, 0x72, 0x69, 0x66,
+	0x69, 0x63, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x50, 0x0a, 0x0a, 0x6d, 0x75, 0x74, 0x75, 0x61,
+	0x6c, 0x5f, 0x74, 0x6c, 0x73, 0x18, 0x08, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x31, 0x2e, 0x61, 0x67,
+	0x65, 0x6e, 0x74, 0x5f, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x6e, 0x61, 0x6c, 0x2e, 0x4d, 0x69, 0x64,
+	0x64, 0x6c, 0x65, 0x77, 0x61, 0x72, 0x65, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x75, 0x72, 0x61,
+	0x74, 0x69, 0x6f, 0x6e, 0x2e, 0x4d, 0x75, 0x74, 0x75, 0x61, 0x6c, 0x54, 0x4c, 0x53, 0x52, 0x09,
+	0x6d, 0x75, 0x74, 0x75, 0x61, 0x6c, 0x54, 0x6c, 0x73, 0x12, 0x58, 0x0a, 0x0f, 0x72, 0x65, 0x71,
+	0x75, 0x65, 0x73, 0x74, 0x5f, 0x68, 0x65, 0x61, 0x64, 0x65, 0x72, 0x73, 0x18, 0x09, 0x20, 0x01,
+	0x28, 0x0b, 0x32, 0x2f, 0x2e, 0x61, 0x67, 0x65, 0x6e, 0x74, 0x5f, 0x69, 0x6e, 0x74, 0x65, 0x72,
+	0x6e, 0x61, 0x6c, 0x2e, 0x4d, 0x69, 0x64, 0x64, 0x6c, 0x65, 0x77, 0x61, 0x72, 0x65, 0x43, 0x6f,
+	0x6e, 0x66, 0x69, 0x67, 0x75, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x2e, 0x48, 0x65, 0x61, 0x64,
+	0x65, 0x72, 0x73, 0x52, 0x0e, 0x72, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x48, 0x65, 0x61, 0x64,
+	0x65, 0x72, 0x73, 0x12, 0x5a, 0x0a, 0x10, 0x72, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x5f,
+	0x68, 0x65, 0x61, 0x64, 0x65, 0x72, 0x73, 0x18, 0x0a, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x2f, 0x2e,
+	0x61, 0x67, 0x65, 0x6e, 0x74, 0x5f, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x6e, 0x61, 0x6c, 0x2e, 0x4d,
+	0x69, 0x64, 0x64, 0x6c, 0x65, 0x77, 0x61, 0x72, 0x65, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x75,
+	0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x2e, 0x48, 0x65, 0x61, 0x64, 0x65, 0x72, 0x73, 0x52, 0x0f,
+	0x72, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x48, 0x65, 0x61, 0x64, 0x65, 0x72, 0x73, 0x12,
+	0x75, 0x0a, 0x17, 0x77, 0x65, 0x62, 0x73, 0x6f, 0x63, 0x6b, 0x65, 0x74, 0x5f, 0x74, 0x63, 0x70,
+	0x5f, 0x63, 0x6f, 0x6e, 0x76, 0x65, 0x72, 0x74, 0x65, 0x72, 0x18, 0x0b, 0x20, 0x01, 0x28, 0x0b,
+	0x32, 0x3d, 0x2e, 0x61, 0x67, 0x65, 0x6e, 0x74, 0x5f, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x6e, 0x61,
+	0x6c, 0x2e, 0x4d, 0x69, 0x64, 0x64, 0x6c, 0x65, 0x77, 0x61, 0x72, 0x65, 0x43, 0x6f, 0x6e, 0x66,
+	0x69, 0x67, 0x75, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x2e, 0x57, 0x65, 0x62, 0x73, 0x6f, 0x63,
+	0x6b, 0x65, 0x74, 0x54, 0x43, 0x50, 0x43, 0x6f, 0x6e, 0x76, 0x65, 0x72, 0x74, 0x65, 0x72, 0x52,
+	0x15, 0x77, 0x65, 0x62, 0x73, 0x6f, 0x63, 0x6b, 0x65, 0x74, 0x54, 0x63, 0x70, 0x43, 0x6f, 0x6e,
+	0x76, 0x65, 0x72, 0x74, 0x65, 0x72, 0x22, 0x6d, 0x0a, 0x0d, 0x54, 0x43, 0x50, 0x4d, 0x69, 0x64,
+	0x64, 0x6c, 0x65, 0x77, 0x61, 0x72, 0x65, 0x12, 0x5c, 0x0a, 0x0e, 0x69, 0x70, 0x5f, 0x72, 0x65,
+	0x73, 0x74, 0x72, 0x69, 0x63, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32,
+	0x35, 0x2e, 0x61, 0x67, 0x65, 0x6e, 0x74, 0x5f, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x6e, 0x61, 0x6c,
+	0x2e, 0x4d, 0x69, 0x64, 0x64, 0x6c, 0x65, 0x77, 0x61, 0x72, 0x65, 0x43, 0x6f, 0x6e, 0x66, 0x69,
+	0x67, 0x75, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x2e, 0x49, 0x50, 0x52, 0x65, 0x73, 0x74, 0x72,
+	0x69, 0x63, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x0d, 0x69, 0x70, 0x52, 0x65, 0x73, 0x74, 0x72, 0x69,
+	0x63, 0x74, 0x69, 0x6f, 0x6e, 0x22, 0xa0, 0x02, 0x0a, 0x0d, 0x54, 0x4c, 0x53, 0x4d, 0x69, 0x64,
+	0x64, 0x6c, 0x65, 0x77, 0x61, 0x72, 0x65, 0x12, 0x50, 0x0a, 0x0a, 0x6d, 0x75, 0x74, 0x75, 0x61,
+	0x6c, 0x5f, 0x74, 0x6c, 0x73, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x31, 0x2e, 0x61, 0x67,
+	0x65, 0x6e, 0x74, 0x5f, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x6e, 0x61, 0x6c, 0x2e, 0x4d, 0x69, 0x64,
+	0x64, 0x6c, 0x65, 0x77, 0x61, 0x72, 0x65, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x75, 0x72, 0x61,
+	0x74, 0x69, 0x6f, 0x6e, 0x2e, 0x4d, 0x75, 0x74, 0x75, 0x61, 0x6c, 0x54, 0x4c, 0x53, 0x52, 0x09,
+	0x6d, 0x75, 0x74, 0x75, 0x61, 0x6c, 0x54, 0x6c, 0x73, 0x12, 0x5f, 0x0a, 0x0f, 0x74, 0x6c, 0x73,
+	0x5f, 0x74, 0x65, 0x72, 0x6d, 0x69, 0x6e, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x02, 0x20, 0x01,
+	0x28, 0x0b, 0x32, 0x36, 0x2e, 0x61, 0x67, 0x65, 0x6e, 0x74, 0x5f, 0x69, 0x6e, 0x74, 0x65, 0x72,
+	0x6e, 0x61, 0x6c, 0x2e, 0x4d, 0x69, 0x64, 0x64, 0x6c, 0x65, 0x77, 0x61, 0x72, 0x65, 0x43, 0x6f,
+	0x6e, 0x66, 0x69, 0x67, 0x75, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x2e, 0x54, 0x4c, 0x53, 0x54,
+	0x65, 0x72, 0x6d, 0x69, 0x6e, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x0e, 0x74, 0x6c, 0x73, 0x54,
+	0x65, 0x72, 0x6d, 0x69, 0x6e, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x12, 0x5c, 0x0a, 0x0e, 0x69, 0x70,
+	0x5f, 0x72, 0x65, 0x73, 0x74, 0x72, 0x69, 0x63, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x03, 0x20, 0x01,
+	0x28, 0x0b, 0x32, 0x35, 0x2e, 0x61, 0x67, 0x65, 0x6e, 0x74, 0x5f, 0x69, 0x6e, 0x74, 0x65, 0x72,
+	0x6e, 0x61, 0x6c, 0x2e, 0x4d, 0x69, 0x64, 0x64, 0x6c, 0x65, 0x77, 0x61, 0x72, 0x65, 0x43, 0x6f,
+	0x6e, 0x66, 0x69, 0x67, 0x75, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x2e, 0x49, 0x50, 0x52, 0x65,
+	0x73, 0x74, 0x72, 0x69, 0x63, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x0d, 0x69, 0x70, 0x52, 0x65, 0x73,
+	0x74, 0x72, 0x69, 0x63, 0x74, 0x69, 0x6f, 0x6e, 0x42, 0x24, 0x5a, 0x22, 0x67, 0x6f, 0x6c, 0x61,
+	0x6e, 0x67, 0x2e, 0x6e, 0x67, 0x72, 0x6f, 0x6b, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x6e, 0x67, 0x72,
+	0x6f, 0x6b, 0x2f, 0x69, 0x6e, 0x74, 0x65, 0x72, 0x6e, 0x61, 0x6c, 0x2f, 0x70, 0x62, 0x62, 0x06,
+	0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -1049,43 +1374,61 @@ func file_internal_pb_middleware_proto_rawDescGZIP() []byte {
 	return file_internal_pb_middleware_proto_rawDescData
 }
 
-var file_internal_pb_middleware_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
+var file_internal_pb_middleware_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
 var file_internal_pb_middleware_proto_goTypes = []interface{}{
 	(*MiddlewareConfiguration)(nil),                       // 0: agent_internal.MiddlewareConfiguration
-	(*MiddlewareConfiguration_Compression)(nil),           // 1: agent_internal.MiddlewareConfiguration.Compression
-	(*MiddlewareConfiguration_CircuitBreaker)(nil),        // 2: agent_internal.MiddlewareConfiguration.CircuitBreaker
-	(*MiddlewareConfiguration_IPRestriction)(nil),         // 3: agent_internal.MiddlewareConfiguration.IPRestriction
-	(*MiddlewareConfiguration_BasicAuth)(nil),             // 4: agent_internal.MiddlewareConfiguration.BasicAuth
-	(*MiddlewareConfiguration_BasicAuthCredential)(nil),   // 5: agent_internal.MiddlewareConfiguration.BasicAuthCredential
-	(*MiddlewareConfiguration_OAuth)(nil),                 // 6: agent_internal.MiddlewareConfiguration.OAuth
-	(*MiddlewareConfiguration_WebhookVerification)(nil),   // 7: agent_internal.MiddlewareConfiguration.WebhookVerification
-	(*MiddlewareConfiguration_MutualTLS)(nil),             // 8: agent_internal.MiddlewareConfiguration.MutualTLS
-	(*MiddlewareConfiguration_TLSTermination)(nil),        // 9: agent_internal.MiddlewareConfiguration.TLSTermination
-	(*MiddlewareConfiguration_Headers)(nil),               // 10: agent_internal.MiddlewareConfiguration.Headers
-	(*MiddlewareConfiguration_WebsocketTCPConverter)(nil), // 11: agent_internal.MiddlewareConfiguration.WebsocketTCPConverter
-	(*MiddlewareConfiguration_OIDC)(nil),                  // 12: agent_internal.MiddlewareConfiguration.OIDC
-	nil,                                                   // 13: agent_internal.MiddlewareConfiguration.Headers.AddParsedEntry
+	(*HTTPMiddleware)(nil),                                // 1: agent_internal.HTTPMiddleware
+	(*TCPMiddleware)(nil),                                 // 2: agent_internal.TCPMiddleware
+	(*TLSMiddleware)(nil),                                 // 3: agent_internal.TLSMiddleware
+	(*MiddlewareConfiguration_Compression)(nil),           // 4: agent_internal.MiddlewareConfiguration.Compression
+	(*MiddlewareConfiguration_CircuitBreaker)(nil),        // 5: agent_internal.MiddlewareConfiguration.CircuitBreaker
+	(*MiddlewareConfiguration_IPRestriction)(nil),         // 6: agent_internal.MiddlewareConfiguration.IPRestriction
+	(*MiddlewareConfiguration_BasicAuth)(nil),             // 7: agent_internal.MiddlewareConfiguration.BasicAuth
+	(*MiddlewareConfiguration_BasicAuthCredential)(nil),   // 8: agent_internal.MiddlewareConfiguration.BasicAuthCredential
+	(*MiddlewareConfiguration_OAuth)(nil),                 // 9: agent_internal.MiddlewareConfiguration.OAuth
+	(*MiddlewareConfiguration_WebhookVerification)(nil),   // 10: agent_internal.MiddlewareConfiguration.WebhookVerification
+	(*MiddlewareConfiguration_MutualTLS)(nil),             // 11: agent_internal.MiddlewareConfiguration.MutualTLS
+	(*MiddlewareConfiguration_TLSTermination)(nil),        // 12: agent_internal.MiddlewareConfiguration.TLSTermination
+	(*MiddlewareConfiguration_Headers)(nil),               // 13: agent_internal.MiddlewareConfiguration.Headers
+	(*MiddlewareConfiguration_WebsocketTCPConverter)(nil), // 14: agent_internal.MiddlewareConfiguration.WebsocketTCPConverter
+	(*MiddlewareConfiguration_OIDC)(nil),                  // 15: agent_internal.MiddlewareConfiguration.OIDC
+	nil,                                                   // 16: agent_internal.MiddlewareConfiguration.Headers.AddParsedEntry
 }
 var file_internal_pb_middleware_proto_depIdxs = []int32{
-	1,  // 0: agent_internal.MiddlewareConfiguration.compression:type_name -> agent_internal.MiddlewareConfiguration.Compression
-	2,  // 1: agent_internal.MiddlewareConfiguration.circuit_breaker:type_name -> agent_internal.MiddlewareConfiguration.CircuitBreaker
-	3,  // 2: agent_internal.MiddlewareConfiguration.ip_restriction:type_name -> agent_internal.MiddlewareConfiguration.IPRestriction
-	4,  // 3: agent_internal.MiddlewareConfiguration.basic_auth:type_name -> agent_internal.MiddlewareConfiguration.BasicAuth
-	6,  // 4: agent_internal.MiddlewareConfiguration.oauth:type_name -> agent_internal.MiddlewareConfiguration.OAuth
-	7,  // 5: agent_internal.MiddlewareConfiguration.webhook_verification:type_name -> agent_internal.MiddlewareConfiguration.WebhookVerification
-	8,  // 6: agent_internal.MiddlewareConfiguration.mutual_tls:type_name -> agent_internal.MiddlewareConfiguration.MutualTLS
-	9,  // 7: agent_internal.MiddlewareConfiguration.tls_termination:type_name -> agent_internal.MiddlewareConfiguration.TLSTermination
-	10, // 8: agent_internal.MiddlewareConfiguration.request_headers:type_name -> agent_internal.MiddlewareConfiguration.Headers
-	10, // 9: agent_internal.MiddlewareConfiguration.response_headers:type_name -> agent_internal.MiddlewareConfiguration.Headers
-	11, // 10: agent_internal.MiddlewareConfiguration.websocket_tcp_converter:type_name -> agent_internal.MiddlewareConfiguration.WebsocketTCPConverter
-	12, // 11: agent_internal.MiddlewareConfiguration.oidc:type_name -> agent_internal.MiddlewareConfiguration.OIDC
-	5,  // 12: agent_internal.MiddlewareConfiguration.BasicAuth.credentials:type_name -> agent_internal.MiddlewareConfiguration.BasicAuthCredential
-	13, // 13: agent_internal.MiddlewareConfiguration.Headers.addParsed:type_name -> agent_internal.MiddlewareConfiguration.Headers.AddParsedEntry
-	14, // [14:14] is the sub-list for method output_type
-	14, // [14:14] is the sub-list for method input_type
-	14, // [14:14] is the sub-list for extension type_name
-	14, // [14:14] is the sub-list for extension extendee
-	0,  // [0:14] is the sub-list for field type_name
+	4,  // 0: agent_internal.MiddlewareConfiguration.compression:type_name -> agent_internal.MiddlewareConfiguration.Compression
+	5,  // 1: agent_internal.MiddlewareConfiguration.circuit_breaker:type_name -> agent_internal.MiddlewareConfiguration.CircuitBreaker
+	6,  // 2: agent_internal.MiddlewareConfiguration.ip_restriction:type_name -> agent_internal.MiddlewareConfiguration.IPRestriction
+	7,  // 3: agent_internal.MiddlewareConfiguration.basic_auth:type_name -> agent_internal.MiddlewareConfiguration.BasicAuth
+	9,  // 4: agent_internal.MiddlewareConfiguration.oauth:type_name -> agent_internal.MiddlewareConfiguration.OAuth
+	10, // 5: agent_internal.MiddlewareConfiguration.webhook_verification:type_name -> agent_internal.MiddlewareConfiguration.WebhookVerification
+	11, // 6: agent_internal.MiddlewareConfiguration.mutual_tls:type_name -> agent_internal.MiddlewareConfiguration.MutualTLS
+	12, // 7: agent_internal.MiddlewareConfiguration.tls_termination:type_name -> agent_internal.MiddlewareConfiguration.TLSTermination
+	13, // 8: agent_internal.MiddlewareConfiguration.request_headers:type_name -> agent_internal.MiddlewareConfiguration.Headers
+	13, // 9: agent_internal.MiddlewareConfiguration.response_headers:type_name -> agent_internal.MiddlewareConfiguration.Headers
+	14, // 10: agent_internal.MiddlewareConfiguration.websocket_tcp_converter:type_name -> agent_internal.MiddlewareConfiguration.WebsocketTCPConverter
+	15, // 11: agent_internal.MiddlewareConfiguration.oidc:type_name -> agent_internal.MiddlewareConfiguration.OIDC
+	4,  // 12: agent_internal.HTTPMiddleware.compression:type_name -> agent_internal.MiddlewareConfiguration.Compression
+	5,  // 13: agent_internal.HTTPMiddleware.circuit_breaker:type_name -> agent_internal.MiddlewareConfiguration.CircuitBreaker
+	6,  // 14: agent_internal.HTTPMiddleware.ip_restriction:type_name -> agent_internal.MiddlewareConfiguration.IPRestriction
+	7,  // 15: agent_internal.HTTPMiddleware.basic_auth:type_name -> agent_internal.MiddlewareConfiguration.BasicAuth
+	9,  // 16: agent_internal.HTTPMiddleware.oauth:type_name -> agent_internal.MiddlewareConfiguration.OAuth
+	15, // 17: agent_internal.HTTPMiddleware.oidc:type_name -> agent_internal.MiddlewareConfiguration.OIDC
+	10, // 18: agent_internal.HTTPMiddleware.webhook_verification:type_name -> agent_internal.MiddlewareConfiguration.WebhookVerification
+	11, // 19: agent_internal.HTTPMiddleware.mutual_tls:type_name -> agent_internal.MiddlewareConfiguration.MutualTLS
+	13, // 20: agent_internal.HTTPMiddleware.request_headers:type_name -> agent_internal.MiddlewareConfiguration.Headers
+	13, // 21: agent_internal.HTTPMiddleware.response_headers:type_name -> agent_internal.MiddlewareConfiguration.Headers
+	14, // 22: agent_internal.HTTPMiddleware.websocket_tcp_converter:type_name -> agent_internal.MiddlewareConfiguration.WebsocketTCPConverter
+	6,  // 23: agent_internal.TCPMiddleware.ip_restriction:type_name -> agent_internal.MiddlewareConfiguration.IPRestriction
+	11, // 24: agent_internal.TLSMiddleware.mutual_tls:type_name -> agent_internal.MiddlewareConfiguration.MutualTLS
+	12, // 25: agent_internal.TLSMiddleware.tls_termination:type_name -> agent_internal.MiddlewareConfiguration.TLSTermination
+	6,  // 26: agent_internal.TLSMiddleware.ip_restriction:type_name -> agent_internal.MiddlewareConfiguration.IPRestriction
+	8,  // 27: agent_internal.MiddlewareConfiguration.BasicAuth.credentials:type_name -> agent_internal.MiddlewareConfiguration.BasicAuthCredential
+	16, // 28: agent_internal.MiddlewareConfiguration.Headers.addParsed:type_name -> agent_internal.MiddlewareConfiguration.Headers.AddParsedEntry
+	29, // [29:29] is the sub-list for method output_type
+	29, // [29:29] is the sub-list for method input_type
+	29, // [29:29] is the sub-list for extension type_name
+	29, // [29:29] is the sub-list for extension extendee
+	0,  // [0:29] is the sub-list for field type_name
 }
 
 func init() { file_internal_pb_middleware_proto_init() }
@@ -1107,7 +1450,7 @@ func file_internal_pb_middleware_proto_init() {
 			}
 		}
 		file_internal_pb_middleware_proto_msgTypes[1].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*MiddlewareConfiguration_Compression); i {
+			switch v := v.(*HTTPMiddleware); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1119,7 +1462,7 @@ func file_internal_pb_middleware_proto_init() {
 			}
 		}
 		file_internal_pb_middleware_proto_msgTypes[2].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*MiddlewareConfiguration_CircuitBreaker); i {
+			switch v := v.(*TCPMiddleware); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1131,7 +1474,7 @@ func file_internal_pb_middleware_proto_init() {
 			}
 		}
 		file_internal_pb_middleware_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*MiddlewareConfiguration_IPRestriction); i {
+			switch v := v.(*TLSMiddleware); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1143,7 +1486,7 @@ func file_internal_pb_middleware_proto_init() {
 			}
 		}
 		file_internal_pb_middleware_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*MiddlewareConfiguration_BasicAuth); i {
+			switch v := v.(*MiddlewareConfiguration_Compression); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1155,7 +1498,7 @@ func file_internal_pb_middleware_proto_init() {
 			}
 		}
 		file_internal_pb_middleware_proto_msgTypes[5].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*MiddlewareConfiguration_BasicAuthCredential); i {
+			switch v := v.(*MiddlewareConfiguration_CircuitBreaker); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1167,7 +1510,7 @@ func file_internal_pb_middleware_proto_init() {
 			}
 		}
 		file_internal_pb_middleware_proto_msgTypes[6].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*MiddlewareConfiguration_OAuth); i {
+			switch v := v.(*MiddlewareConfiguration_IPRestriction); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1179,7 +1522,7 @@ func file_internal_pb_middleware_proto_init() {
 			}
 		}
 		file_internal_pb_middleware_proto_msgTypes[7].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*MiddlewareConfiguration_WebhookVerification); i {
+			switch v := v.(*MiddlewareConfiguration_BasicAuth); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1191,7 +1534,7 @@ func file_internal_pb_middleware_proto_init() {
 			}
 		}
 		file_internal_pb_middleware_proto_msgTypes[8].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*MiddlewareConfiguration_MutualTLS); i {
+			switch v := v.(*MiddlewareConfiguration_BasicAuthCredential); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1203,7 +1546,7 @@ func file_internal_pb_middleware_proto_init() {
 			}
 		}
 		file_internal_pb_middleware_proto_msgTypes[9].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*MiddlewareConfiguration_TLSTermination); i {
+			switch v := v.(*MiddlewareConfiguration_OAuth); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1215,7 +1558,7 @@ func file_internal_pb_middleware_proto_init() {
 			}
 		}
 		file_internal_pb_middleware_proto_msgTypes[10].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*MiddlewareConfiguration_Headers); i {
+			switch v := v.(*MiddlewareConfiguration_WebhookVerification); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1227,7 +1570,7 @@ func file_internal_pb_middleware_proto_init() {
 			}
 		}
 		file_internal_pb_middleware_proto_msgTypes[11].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*MiddlewareConfiguration_WebsocketTCPConverter); i {
+			switch v := v.(*MiddlewareConfiguration_MutualTLS); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1239,6 +1582,42 @@ func file_internal_pb_middleware_proto_init() {
 			}
 		}
 		file_internal_pb_middleware_proto_msgTypes[12].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*MiddlewareConfiguration_TLSTermination); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_internal_pb_middleware_proto_msgTypes[13].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*MiddlewareConfiguration_Headers); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_internal_pb_middleware_proto_msgTypes[14].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*MiddlewareConfiguration_WebsocketTCPConverter); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_internal_pb_middleware_proto_msgTypes[15].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*MiddlewareConfiguration_OIDC); i {
 			case 0:
 				return &v.state
@@ -1257,7 +1636,7 @@ func file_internal_pb_middleware_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_internal_pb_middleware_proto_rawDesc,
 			NumEnums:      0,
-			NumMessages:   14,
+			NumMessages:   17,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/internal/tunnel/proto/msg.go
+++ b/internal/tunnel/proto/msg.go
@@ -41,10 +41,20 @@ type Auth struct {
 	Extra    AuthExtra // clients may add whatever data the like to auth messages
 }
 
+type ObfuscatedString string
+
+func (t ObfuscatedString) String() string {
+	return "HIDDEN"
+}
+
+func (t ObfuscatedString) PlainText() string {
+	return string(t)
+}
+
 type AuthExtra struct {
 	OS                 string
 	Arch               string
-	Authtoken          string
+	Authtoken          ObfuscatedString
 	Version            string
 	Hostname           string
 	UserAgent          string

--- a/internal/tunnel/proto/msg_test.go
+++ b/internal/tunnel/proto/msg_test.go
@@ -2,6 +2,7 @@ package proto
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -50,4 +51,16 @@ func TestProtoMiddleware(t *testing.T) {
 	require.Contains(t, rawIsh, "BasicAuth")
 	require.NotEmpty(t, rawIsh["BasicAuth"].(map[string]any)["credentials"])
 	require.Empty(t, rawIsh["MiddlewareBytes"])
+}
+
+func TestObfuscatedString(t *testing.T) {
+	t.Parallel()
+
+	fakeToken := "weeeeee"
+	obfuscatedString := ObfuscatedString(fakeToken)
+	require.Equal(t, fakeToken, obfuscatedString.PlainText())
+
+	printedString := fmt.Sprintf("%s", obfuscatedString)
+	require.NotEqual(t, fakeToken, printedString)
+	require.Equal(t, "HIDDEN", printedString)
 }

--- a/session.go
+++ b/session.go
@@ -85,7 +85,7 @@ type ConnectOption func(*connectConfig)
 // Options to use when establishing an ngrok session.
 type connectConfig struct {
 	// Your ngrok Authtoken.
-	Authtoken string
+	Authtoken proto.ObfuscatedString
 	// The address of the ngrok server to connect to.
 	// Defaults to `tunnel.ngrok.com:443`
 	ServerAddr string
@@ -157,7 +157,7 @@ func WithProxyURL(url *url.URL) ConnectOption {
 // Sets the [ConnectConfig].Authtoken field.
 func WithAuthtoken(token string) ConnectOption {
 	return func(cfg *connectConfig) {
-		cfg.Authtoken = token
+		cfg.Authtoken = proto.ObfuscatedString(token)
 	}
 }
 
@@ -343,7 +343,7 @@ func Connect(ctx context.Context, opts ...ConnectOption) (Session, error) {
 
 	auth := proto.AuthExtra{
 		Version:            libraryAgentVersion,
-		Authtoken:          cfg.Authtoken,
+		Authtoken:          proto.ObfuscatedString(cfg.Authtoken),
 		Metadata:           cfg.Metadata,
 		OS:                 runtime.GOOS,
 		Arch:               runtime.GOARCH,


### PR DESCRIPTION
Pulling in a security fix from our agent copy.