### PR TITLE
Allow setting ForwardsTo for labeled tunnels

### DIFF
--- a/config/forwards_to.go
+++ b/config/forwards_to.go
@@ -10,6 +10,7 @@ import (
 // This can be veiwed via the API or dashboard.
 func WithForwardsTo(meta string) interface {
 	HTTPEndpointOption
+	LabeledTunnelOption
 	TCPEndpointOption
 	TLSEndpointOption
 } {

--- a/config/labeled_test.go
+++ b/config/labeled_test.go
@@ -30,6 +30,16 @@ func TestLabeled(t *testing.T) {
 			}),
 			expectNilOpts: true,
 		},
+		{
+			name: "withForwardsTo",
+			opts: LabeledTunnel(WithLabel("foo", "bar"), WithForwardsTo("localhost:8080")),
+			expectLabels: labelPtr(map[string]*string{
+				"foo": stringPtr("bar"),
+			}),
+			expectForwardsTo: stringPtr("localhost:8080"),
+			expectProto:      stringPtr(""),
+			expectNilOpts:    true,
+		},
 	}
 
 	cases.runAll(t)

--- a/config/labeled_test.go
+++ b/config/labeled_test.go
@@ -40,6 +40,18 @@ func TestLabeled(t *testing.T) {
 			expectProto:      stringPtr(""),
 			expectNilOpts:    true,
 		},
+		{
+			name: "withMetadata",
+			opts: LabeledTunnel(WithLabel("foo", "bar"), WithMetadata("choochoo")),
+			expectLabels: labelPtr(map[string]*string{
+				"foo": stringPtr("bar"),
+			}),
+			expectExtra: &matchBindExtra{
+				Metadata: stringPtr("choochoo"),
+			},
+			expectProto:   stringPtr(""),
+			expectNilOpts: true,
+		},
 	}
 
 	cases.runAll(t)


### PR DESCRIPTION
Currently, we are not able to set `ForwardsTo` for labeled tunnels. This PR adds the necessary `LabeledTunnelOption` to the returned interface so that we can set `ForwardsTo` for labeled tunnels.