### PR TITLE
session: add user-agent string and allow library consumers to extend it

### DIFF
--- a/session_test.go
+++ b/session_test.go
@@ -1,0 +1,15 @@
+package ngrok
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUserAgent(t *testing.T) {
+	s := (&clientInfo{"library/official/go", "1.2.3"}).ToUserAgent()
+	require.Equal(t, s, "library-official-go/1.2.3")
+
+	s = (&clientInfo{"some@funky☺user agent", "№1.2.3"}).ToUserAgent()
+	require.Equal(t, s, "some#funky#user#agent/#1.2.3")
+}


### PR DESCRIPTION
Allows library consumers to differentiate their application and version from others.

Currently, there is no incentive for folks to use this outside of caring about our internal usage; we should expose this to users via the dashboard & API in the future.