### PR TITLE
session: allow ReconnectingSession to retry temporary failures

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,10 +1,8 @@
 package ngrok
 
 import (
-	"errors"
 	"fmt"
 	"net/url"
-	"strings"
 )
 
 // Errors arising from authentication failure.
@@ -114,57 +112,4 @@ func (e errSessionDial) Unwrap() error {
 func (e errSessionDial) Is(target error) bool {
 	_, ok := target.(errSessionDial)
 	return ok
-}
-
-type errMultiple struct {
-	inners []error
-}
-
-var _ error = &errMultiple{}
-
-func (e *errMultiple) Add(err error) {
-	if err == nil {
-		return
-	}
-
-	e.inners = append(e.inners, err)
-}
-
-func (e *errMultiple) Error() string {
-	switch len(e.inners) {
-	case 0:
-		return "error: no errors recorded"
-	case 1:
-		return e.inners[0].Error()
-	default:
-		errBuilder := strings.Builder{}
-		errBuilder.WriteString("multiple errors occurred:\n")
-		for i := len(e.inners); i > 0; i-- {
-			errBuilder.WriteString(e.inners[i-1].Error())
-			errBuilder.WriteString("\n")
-		}
-		return errBuilder.String()
-	}
-}
-
-func (e *errMultiple) Unwrap() []error {
-	return e.inners
-}
-
-func (e *errMultiple) Is(err error) bool {
-	for _, inner := range e.inners {
-		if errors.Is(inner, err) {
-			return true
-		}
-	}
-	return false
-}
-
-func (e *errMultiple) As(err any) bool {
-	for _, inner := range e.inners {
-		if errors.As(inner, err) {
-			return true
-		}
-	}
-	return false
 }

--- a/errors.go
+++ b/errors.go
@@ -1,8 +1,10 @@
 package ngrok
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
+	"strings"
 )
 
 // Errors arising from authentication failure.
@@ -112,4 +114,57 @@ func (e errSessionDial) Unwrap() error {
 func (e errSessionDial) Is(target error) bool {
 	_, ok := target.(errSessionDial)
 	return ok
+}
+
+type errMultiple struct {
+	inners []error
+}
+
+var _ error = &errMultiple{}
+
+func (e *errMultiple) Add(err error) {
+	if err == nil {
+		return
+	}
+
+	e.inners = append(e.inners, err)
+}
+
+func (e *errMultiple) Error() string {
+	switch len(e.inners) {
+	case 0:
+		return "error: no errors recorded"
+	case 1:
+		return e.inners[0].Error()
+	default:
+		errBuilder := strings.Builder{}
+		errBuilder.WriteString("multiple errors occurred:\n")
+		for i := len(e.inners); i > 0; i-- {
+			errBuilder.WriteString(e.inners[i-1].Error())
+			errBuilder.WriteString("\n")
+		}
+		return errBuilder.String()
+	}
+}
+
+func (e *errMultiple) Unwrap() []error {
+	return e.inners
+}
+
+func (e *errMultiple) Is(err error) bool {
+	for _, inner := range e.inners {
+		if errors.Is(inner, err) {
+			return true
+		}
+	}
+	return false
+}
+
+func (e *errMultiple) As(err any) bool {
+	for _, inner := range e.inners {
+		if errors.As(inner, err) {
+			return true
+		}
+	}
+	return false
 }

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/inconshreveable/log15 v3.0.0-testing.3+incompatible // indirect
 	github.com/kr/text v0.2.0 // indirect
+	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/term v0.2.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
+go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa h1:zuSxTR4o9y82ebqCUJYNGJbGPo6sKVl54f/TVDObg1c=
 golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/net v0.2.0 h1:sZfSu1wtKLGlWI4ZZayP0ck9Y73K1ynO6gqzTdBVdPU=

--- a/online_test.go
+++ b/online_test.go
@@ -681,27 +681,20 @@ func TestRetryableErrors(t *testing.T) {
 	var err error
 	ctx := context.Background()
 
+	// give up on connecting after first attempt
 	disconnect := WithDisconnectHandler(func(_ context.Context, sess Session, disconnectErr error) {
-		// save the first session error and exit
-		if disconnectErr != nil && err == nil {
-			err = disconnectErr
-			sess.Close()
-		}
+		sess.Close()
 	})
 	connect := WithConnectHandler(func(_ context.Context, sess Session) {
-		// exit if connection somehow succeeds
-		err = nil
 		sess.Close()
 	})
 
-	err = nil
-	_, _ = Connect(ctx, WithServer("127.0.0.234:123"), connect, disconnect)
+	_, err = Connect(ctx, WithServer("127.0.0.234:123"), connect, disconnect)
 	var dialErr errSessionDial
 	require.ErrorIs(t, err, dialErr)
 	require.ErrorAs(t, err, &dialErr)
 
-	err = nil
-	_, _ = Connect(ctx, WithAuthtoken("lolnope"), connect, disconnect)
+	_, err = Connect(ctx, WithAuthtoken("lolnope"), connect, disconnect)
 	var authErr errAuthFailed
 	require.ErrorIs(t, err, authErr)
 	require.ErrorAs(t, err, &authErr)

--- a/online_test.go
+++ b/online_test.go
@@ -652,7 +652,7 @@ func TestHeartbeatCallback(t *testing.T) {
 	require.Equal(t, 2, heartbeats, "should've seen some heartbeats")
 }
 
-func TestErrors(t *testing.T) {
+func TestPermanentErrors(t *testing.T) {
 	onlineTest(t)
 	var err error
 	ctx := context.Background()
@@ -663,23 +663,49 @@ func TestErrors(t *testing.T) {
 	require.ErrorIs(t, err, proxyErr)
 	require.ErrorAs(t, err, &proxyErr)
 
-	_, err = Connect(ctx, WithServer("127.0.0.234:123"))
-	var dialErr errSessionDial
-	require.ErrorIs(t, err, dialErr)
-	require.ErrorAs(t, err, &dialErr)
-
-	_, err = Connect(ctx, WithAuthtoken("lolnope"))
-	var authErr errAuthFailed
-	require.ErrorIs(t, err, authErr)
-	require.ErrorAs(t, err, &authErr)
-	require.True(t, authErr.Remote)
-
 	sess, err := Connect(ctx)
 	require.NoError(t, err)
 	_, err = sess.Listen(ctx, config.TCPEndpoint())
 	var startErr errListen
 	require.ErrorIs(t, err, startErr)
 	require.ErrorAs(t, err, &startErr)
+
+	timeoutCtx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+	_, err = Connect(timeoutCtx, WithServer("127.0.0.234:123"))
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestRetryableErrors(t *testing.T) {
+	onlineTest(t)
+	var err error
+	ctx := context.Background()
+
+	disconnect := WithDisconnectHandler(func(_ context.Context, sess Session, disconnectErr error) {
+		// save the first session error and exit
+		if disconnectErr != nil && err == nil {
+			err = disconnectErr
+			sess.Close()
+		}
+	})
+	connect := WithConnectHandler(func(_ context.Context, sess Session) {
+		// exit if connection somehow succeeds
+		err = nil
+		sess.Close()
+	})
+
+	err = nil
+	_, _ = Connect(ctx, WithServer("127.0.0.234:123"), connect, disconnect)
+	var dialErr errSessionDial
+	require.ErrorIs(t, err, dialErr)
+	require.ErrorAs(t, err, &dialErr)
+
+	err = nil
+	_, _ = Connect(ctx, WithAuthtoken("lolnope"), connect, disconnect)
+	var authErr errAuthFailed
+	require.ErrorIs(t, err, authErr)
+	require.ErrorAs(t, err, &authErr)
+	require.True(t, authErr.Remote)
 }
 
 func TestNonExported(t *testing.T) {

--- a/session.go
+++ b/session.go
@@ -311,8 +311,8 @@ func WithLogger(logger log.Logger) ConnectOption {
 
 // WithConnectHandler configures a function which is called each time the ngrok
 // [Session] successfully connects to the ngrok service. Use this option to
-// receive events when ngrok successfully reconnects a [Session] that was
-// disconnected because of a network failure.
+// receive events when the [Session] successfully connects or reconnects after
+// a disconnection due to network failure.
 func WithConnectHandler(handler SessionConnectHandler) ConnectOption {
 	return func(cfg *connectConfig) {
 		cfg.ConnectHandler = handler
@@ -322,6 +322,13 @@ func WithConnectHandler(handler SessionConnectHandler) ConnectOption {
 // WithDisconnectHandler configures a function which is called each time the
 // ngrok [Session] disconnects from the ngrok service. Use this option to detect
 // when the ngrok session has gone temporarily offline.
+//
+// This handler will be called every time a [Session] encounters an error during
+// or after connection. It may be called multiple times in a row, and it may be
+// called before any Connect handler is called and before [Connect] returns.
+//
+// If this function is called with a nil error, the [Session] has stopped trying
+// to connect, usually due to [Session.Close] being called.
 func WithDisconnectHandler(handler SessionDisconnectHandler) ConnectOption {
 	return func(cfg *connectConfig) {
 		cfg.DisconnectHandler = handler

--- a/session.go
+++ b/session.go
@@ -445,10 +445,12 @@ func WithUpdateCommandDisabled(err string) ConnectOption {
 	}
 }
 
-// Connect begins a new ngrok [Session] by connecting to the ngrok service.
+// Connect begins a new ngrok [Session] by connecting to the ngrok service,
+// retrying transient failures if they occur.
+//
 // Connect blocks until the session is successfully established or fails with
-// an error. Customize session connection behavior with [ConnectOption]
-// arguments.
+// an error that will not be retried. Customize session connection behavior
+// with [ConnectOption] arguments.
 func Connect(ctx context.Context, opts ...ConnectOption) (Session, error) {
 	logger := log15.New()
 	logger.SetHandler(log15.DiscardHandler())

--- a/session.go
+++ b/session.go
@@ -108,7 +108,7 @@ func generateInfo(cs []clientInfo) (string, string, string) {
 	return strings.Join(versions, ","), strings.Join(types, ","), strings.Join(uas, " ")
 }
 
-// Options to use when establishing an ngrok session.
+// Options to use when establishing the ngrok session.
 type connectConfig struct {
 	// Your ngrok Authtoken.
 	Authtoken proto.ObfuscatedString
@@ -324,7 +324,7 @@ func WithConnectHandler(handler SessionConnectHandler) ConnectOption {
 // ngrok [Session] disconnects from the ngrok service. Use this option to detect
 // when the ngrok session has gone temporarily offline.
 //
-// This handler will be called every time a [Session] encounters an error during
+// This handler will be called every time the [Session] encounters an error during
 // or after connection. It may be called multiple times in a row; it may be
 // called before any Connect handler is called and before [Connect] returns.
 //

--- a/session.go
+++ b/session.go
@@ -325,11 +325,11 @@ func WithConnectHandler(handler SessionConnectHandler) ConnectOption {
 // when the ngrok session has gone temporarily offline.
 //
 // This handler will be called every time a [Session] encounters an error during
-// or after connection. It may be called multiple times in a row, and it may be
+// or after connection. It may be called multiple times in a row; it may be
 // called before any Connect handler is called and before [Connect] returns.
 //
-// If this function is called with a nil error, the [Session] has stopped trying
-// to connect, usually due to [Session.Close] being called.
+// If this function is called with a nil error, the [Session] has stopped and will
+// not reconnect, usually due to [Session.Close] being called.
 func WithDisconnectHandler(handler SessionDisconnectHandler) ConnectOption {
 	return func(cfg *connectConfig) {
 		cfg.DisconnectHandler = handler


### PR DESCRIPTION
In the case of a temporary failure in ReconnectingSession, an error is placed into the stateChanges channel. This error does not necessarily mean that failure is permanent and that the connection process should abort. For example, in the case of a dial error when initially connecting the session, we desire to retry dialing with backoff as implemented by ReconnectingSession, unless the library consumer intentionally wants to cancel connecting based on that error.

Only in the case of a permanent connection failure do we want to cancel the connection process and return an error to the consumer.

Therefore, we expose all connection errors to the library consumer via the Disconnect handler, allowing them, if they so choose, to .Close() an open session that is erroring (e.g., on authentication or restarting tunnel binds). The Connect function returns only upon permanent failure, in which case it returns nil and the last error read from stateChanges; or upon connection success, in which case it returns a happy Session. In the case of permanent failure, the Disconnect handler will have already received the error; thus, for consumers defining a Disconnect handler it is not necessary to handle the error returned from Connect.

This PR also ensures the guarantee that whenever the underlying session closes, the Disconnect handler is called with `err = nil`.