### PR TITLE
add connection proxy metadata

### DIFF
--- a/internal/tunnel/proto/msg.go
+++ b/internal/tunnel/proto/msg.go
@@ -270,10 +270,10 @@ type EdgeType int32
 
 // in sync with rpx.EdgesTypes_Edge
 const (
-	EdgeTypeUndefined = 0
-	EdgeTypeTCP       = 1
-	EdgeTypeTLS       = 2
-	EdgeTypeHTTPS     = 3
+	EdgeTypeUndefined EdgeType = 0
+	EdgeTypeTCP                = 1
+	EdgeTypeTLS                = 2
+	EdgeTypeHTTPS              = 3
 )
 
 func ParseEdgeType(et string) (EdgeType, bool) {

--- a/online_test.go
+++ b/online_test.go
@@ -99,6 +99,26 @@ func TestTunnel(t *testing.T) {
 	require.Equal(t, "some application", tun.ForwardsTo())
 }
 
+func TestTunnelConnMetadata(t *testing.T) {
+	ctx := context.Background()
+	sess := setupSession(ctx, t)
+
+	tun := startTunnel(ctx, t, sess, config.HTTPEndpoint())
+
+	go func() {
+		_, _ = http.Get(tun.URL())
+	}()
+
+	conn, err := tun.Accept()
+	require.NoError(t, err)
+
+	proxyconn, ok := conn.(Conn)
+	require.True(t, ok, "conn doesn't implement proxy conn interface")
+
+	require.Equal(t, "https", proxyconn.Proto())
+	require.Equal(t, EdgeTypeUndefined, proxyconn.EdgeType())
+}
+
 func TestWithHTTPHandler(t *testing.T) {
 	ctx := context.Background()
 	sess := setupSession(ctx, t)


### PR DESCRIPTION
Expose the tunnel proto, edge type, and passthrough tls for each connection to a tunnel. Re-export the internal edge type constants so consumers can use constants instead of magic number strings.