### PR TITLE
DNM Add configuration helper for TLS to mimic the behavior of `terminate-at edge`

### DIFF
--- a/config/tls_termination.go
+++ b/config/tls_termination.go
@@ -8,3 +8,11 @@ func WithTermination(certPEM, keyPEM []byte) TLSEndpointOption {
 		cfg.KeyPEM = keyPEM
 	})
 }
+
+// WithManagedTermination sets the TLS termination at edge for ngrok managed domains.
+func WithManagedTermination() TLSEndpointOption {
+	return tlsOptionFunc(func(cfg *tlsOptions) {
+		cfg.CertPEM = []byte{}
+		cfg.KeyPEM = []byte{}
+	})
+}

--- a/config/tls_termination_test.go
+++ b/config/tls_termination_test.go
@@ -27,6 +27,16 @@ func TestTLSTermination(t *testing.T) {
 				require.Equal(t, []byte("key"), actual.Key)
 			},
 		},
+		{
+			name: "managed",
+			opts: TLSEndpoint(WithManagedTermination()),
+			expectOpts: func(t *testing.T, opts *proto.TLSEndpoint) {
+				actual := opts.TLSTermination
+				require.NotNil(t, actual)
+				require.NotNil(t, actual.Cert)
+				require.NotNil(t, actual.Key)
+			},
+		},
 	}
 
 	cases.runAll(t)


### PR DESCRIPTION
Elaborates further on the https://github.com/ngrok/ngrok-go/issues/86