### PR TITLE
Deprecate WithTermination in favor of clearer WithEdgeTermination and WithCustomEdgeTermination

### DIFF
--- a/config/tls_termination.go
+++ b/config/tls_termination.go
@@ -1,10 +1,81 @@
 package config
 
+type TLSTerminationLocation int
+
+const (
+	// Terminate TLS at the ngrok edge. The backend will receive a plaintext
+	// stream.
+	TLSAtEdge TLSTerminationLocation = iota
+	// Terminate TLS in the ngrok library. The library will receive the
+	// handshake and perform TLS termination, and the backend will receive the
+	// plaintext stream.
+	// TODO: export this once implmented
+	tlsAtLibrary
+)
+
+type tlsTermination struct {
+	location TLSTerminationLocation
+	key      []byte
+	cert     []byte
+}
+
+func (tt tlsTermination) ApplyTLS(cfg *tlsOptions) {
+	switch tt.location {
+	case tlsAtLibrary:
+		cfg.KeyPEM = nil
+		cfg.CertPEM = nil
+		// TODO: implement this in the tunnel `Accept` call.
+		panic("automatic tls termination in-app is not yet supported")
+	case TLSAtEdge:
+		cfg.KeyPEM = tt.key
+		cfg.CertPEM = tt.cert
+		return
+	}
+}
+
+type TLSTerminationOption func(tt *tlsTermination)
+
+// WithTLSTermination arranges for incoming TLS connections to be automatically terminated.
+// The backend will then receive plaintext streams, rather than raw TLS connections.
+// Defaults to terminating TLS at the ngrok edge with an automatically-provisioned keypair.
+func WithTLSTermination(opts ...TLSTerminationOption) TLSEndpointOption {
+	tt := tlsTermination{
+		location: TLSAtEdge,
+		key:      []byte{},
+		cert:     []byte{},
+	}
+	for _, opt := range opts {
+		opt(&tt)
+	}
+	return tt
+}
+
 // WithTermination sets the key and certificate in PEM format for TLS termination at the ngrok
 // edge.
+//
+// Deprecated: Use WithCustomEdgeTermination instead.
 func WithTermination(certPEM, keyPEM []byte) TLSEndpointOption {
 	return tlsOptionFunc(func(cfg *tlsOptions) {
 		cfg.CertPEM = certPEM
 		cfg.KeyPEM = keyPEM
+	})
+}
+
+// WithTLSTerminationAt determines where TLS termination should occur.
+// Currently, only `TLSAtEdge` is supported.
+func WithTLSTerminationAt(location TLSTerminationLocation) TLSTerminationOption {
+	return TLSTerminationOption(func(cfg *tlsTermination) {
+		cfg.location = location
+	})
+}
+
+// WithTLSTerminationKeyPair sets a custom key and certificate in PEM format for
+// TLS termination.
+// If terminating at the ngrok edge, this uploads the private key and
+// certificate to the ngrok servers.
+func WithTLSTerminationKeyPair(certPEM, keyPEM []byte) TLSTerminationOption {
+	return TLSTerminationOption(func(cfg *tlsTermination) {
+		cfg.cert = certPEM
+		cfg.key = keyPEM
 	})
 }

--- a/config/tls_termination_test.go
+++ b/config/tls_termination_test.go
@@ -27,6 +27,26 @@ func TestTLSTermination(t *testing.T) {
 				require.Equal(t, []byte("key"), actual.Key)
 			},
 		},
+		{
+			name: "with new termination",
+			opts: TLSEndpoint(WithTLSTermination()),
+			expectOpts: func(t *testing.T, opts *proto.TLSEndpoint) {
+				actual := opts.TLSTermination
+				require.NotNil(t, actual)
+				require.Equal(t, []byte{}, actual.Cert)
+				require.Equal(t, []byte{}, actual.Key)
+			},
+		},
+		{
+			name: "with new custom termination",
+			opts: TLSEndpoint(WithTLSTermination(WithTLSTerminationKeyPair([]byte("cert"), []byte("key")))),
+			expectOpts: func(t *testing.T, opts *proto.TLSEndpoint) {
+				actual := opts.TLSTermination
+				require.NotNil(t, actual)
+				require.Equal(t, []byte("cert"), actual.Cert)
+				require.Equal(t, []byte("key"), actual.Key)
+			},
+		},
 	}
 
 	cases.runAll(t)


### PR DESCRIPTION
Resolves #86

We'll probably want to add a `WithAgentTermination` as well, but that
will be a little more involved, and may fit into the built-in connection
forwarding better.
