### PR TITLE
fix (and test) websockets

### DIFF
--- a/internal/muxado/buffer.go
+++ b/internal/muxado/buffer.go
@@ -131,13 +131,11 @@ func (b *inboundBuffer) SetDeadline(t time.Time) {
 	b.deadline = t
 	if timeout := time.Until(t); timeout > 0 {
 		b.startTimerLocked(timeout)
+	} else {
+		b.stopTimerLocked()
 	}
 
-	if t.IsZero() {
-		b.stopTimerLocked()
-	} else {
-		b.cond.Broadcast()
-	}
+	b.cond.Broadcast()
 
 	b.mu.Unlock()
 }

--- a/internal/muxado/buffer.go
+++ b/internal/muxado/buffer.go
@@ -132,7 +132,12 @@ func (b *inboundBuffer) SetDeadline(t time.Time) {
 	if timeout := time.Until(t); timeout > 0 {
 		b.startTimerLocked(timeout)
 	}
-	b.cond.Broadcast()
+
+	if t.IsZero() {
+		b.stopTimerLocked()
+	} else {
+		b.cond.Broadcast()
+	}
 
 	b.mu.Unlock()
 }

--- a/internal/muxado/stream.go
+++ b/internal/muxado/stream.go
@@ -106,6 +106,7 @@ func (s *stream) Read(buf []byte) (int, error) {
 // - If the stream receives another STREAM_DATA frame (except an empty one with a FIN)
 //   from the remote side, it will send a STREAM_RST with a CANCELED error code
 func (s *stream) Close() error {
+	s.bufImpl.Close()
 	s.CloseWrite()
 	s.closeWith(closeError)
 	return nil


### PR DESCRIPTION
Back in the day, Go didn't have very good cancellation semantics. I
mean, it still doesn't, but it's "better."

All of the old io interfaces lack a context argument to check
to see if their blocking call has been canceled. Therefore, if you
spawn off a "reader" task, how do you tell it to quit reading? You can
handle exiting the loop easy enough on your own, but what if the `Read`
method never returns? You still need a way to cancel _that_.

The solution? `Conn.SetDeadline` to "a long time ago!"

No, seriously:
```go
func (cr *connReader) abortPendingRead() {
	cr.lock()
	defer cr.unlock()
	if !cr.inRead {
		return
	}
	cr.aborted = true
	cr.conn.rwc.SetReadDeadline(aLongTimeAgo)
	for cr.inRead {
		cr.cond.Wait()
	}
	cr.conn.rwc.SetReadDeadline(time.Time{})
}
```

To be fair, its usage as a cancellation mechanism [is documented](https://pkg.go.dev/net#Conn), but it's still less-than-obvious.

Anyway, this `abortPendingRead` is in the callstack for the `Hijack`
method for the response writer, which is how websocket connections get
taken over for their nefarious non-http purposes. Because we didn't have
`SetDeadline` implemented for this buffer type, the in-flight reads were
never getting canceled, so this "abort" call never finished, and the
websocket handler was stuck waiting forever for a connection.
