### PR TITLE
update user agent filter flags to be consistent

### DIFF
--- a/config/user_agent_filter.go
+++ b/config/user_agent_filter.go
@@ -12,7 +12,7 @@ type userAgentFilter struct {
 	Deny []string
 }
 
-// WithAllowUserAgentFilter adds user agent filtering to the endpoint.
+// WithAllowUserAgent adds user agent filtering to the endpoint.
 //
 // The allow argument is a regular expressions for the user-agent
 // header to allow
@@ -23,14 +23,14 @@ type userAgentFilter struct {
 // ERR_NGROK_2090 for invalid allow/deny on connect.
 // ERR_NGROK_3211 The server does not authorize requests from your user-agent
 // ERR_NGROK_9022 Your account is not authorized to use user agent filtering.
-func WithAllowUserAgentFilter(allow ...string) HTTPEndpointOption {
-	return userAgentFilter{
+func WithAllowUserAgent(allow ...string) HTTPEndpointOption {
+	return &userAgentFilter{
 		// slice of regex strings for allowed user agents
 		Allow: allow,
 	}
 }
 
-// WithDenyUserAgentFilter adds user agent filtering to the endpoint.
+// WithDenyUserAgent adds user agent filtering to the endpoint.
 //
 // The deny argument is a regular expressions to
 // deny, with allows taking precedence over denies.
@@ -41,8 +41,8 @@ func WithAllowUserAgentFilter(allow ...string) HTTPEndpointOption {
 // ERR_NGROK_2090 for invalid allow/deny on connect.
 // ERR_NGROK_3211 The server does not authorize requests from your user-agent
 // ERR_NGROK_9022 Your account is not authorized to use user agent filtering.
-func WithDenyUserAgentFilter(deny ...string) HTTPEndpointOption {
-	return userAgentFilter{
+func WithDenyUserAgent(deny ...string) HTTPEndpointOption {
+	return &userAgentFilter{
 		// slice of regex strings for denied user agents
 		Deny: deny,
 	}

--- a/config/user_agent_filter_test.go
+++ b/config/user_agent_filter_test.go
@@ -28,7 +28,7 @@ func testUserAgentFilter[T tunnelConfigPrivate, O any, OT any](t *testing.T,
 		{
 			name: "test allow",
 			opts: optsFunc(
-				WithAllowUserAgentFilter(`(Pingdom\.com_bot_version_)(\d+)\.(\d+)`),
+				WithAllowUserAgent(`(Pingdom\.com_bot_version_)(\d+)\.(\d+)`),
 			),
 			expectOpts: func(t *testing.T, opts *O) {
 				actual := getUserAgentFilter(opts)
@@ -43,7 +43,7 @@ func testUserAgentFilter[T tunnelConfigPrivate, O any, OT any](t *testing.T,
 		{
 			name: "test deny",
 			opts: optsFunc(
-				WithDenyUserAgentFilter(`(Pingdom\.com_bot_version_)(\d+)\.(\d+)`),
+				WithDenyUserAgent(`(Pingdom\.com_bot_version_)(\d+)\.(\d+)`),
 			),
 			expectOpts: func(t *testing.T, opts *O) {
 				actual := getUserAgentFilter(opts)
@@ -58,8 +58,8 @@ func testUserAgentFilter[T tunnelConfigPrivate, O any, OT any](t *testing.T,
 		{
 			name: "test allow and deny",
 			opts: optsFunc(
-				WithAllowUserAgentFilter(`(Pingdom\.com_bot_version_)(\d+)\.(\d+)`),
-				WithDenyUserAgentFilter(`(Pingdom\.com_bot_version_)(\d+)\.(\d+)`),
+				WithAllowUserAgent(`(Pingdom\.com_bot_version_)(\d+)\.(\d+)`),
+				WithDenyUserAgent(`(Pingdom\.com_bot_version_)(\d+)\.(\d+)`),
 			),
 			expectOpts: func(t *testing.T, opts *O) {
 				actual := getUserAgentFilter(opts)
@@ -73,10 +73,10 @@ func testUserAgentFilter[T tunnelConfigPrivate, O any, OT any](t *testing.T,
 		{
 			name: "test multiple",
 			opts: optsFunc(
-				WithAllowUserAgentFilter(`(Pingdom\.com_bot_version_)(\d+)\.(\d+)`),
-				WithDenyUserAgentFilter(`(Pingdom\.com_bot_version_)(\d+)\.(\d+)`),
-				WithAllowUserAgentFilter(`(Pingdom2\.com_bot_version_)(\d+)\.(\d+)`),
-				WithDenyUserAgentFilter(`(Pingdom2\.com_bot_version_)(\d+)\.(\d+)`),
+				WithAllowUserAgent(`(Pingdom\.com_bot_version_)(\d+)\.(\d+)`),
+				WithDenyUserAgent(`(Pingdom\.com_bot_version_)(\d+)\.(\d+)`),
+				WithAllowUserAgent(`(Pingdom2\.com_bot_version_)(\d+)\.(\d+)`),
+				WithDenyUserAgent(`(Pingdom2\.com_bot_version_)(\d+)\.(\d+)`),
 			),
 			expectOpts: func(t *testing.T, opts *O) {
 				actual := getUserAgentFilter(opts)


### PR DESCRIPTION
aligning the terminology for:
`WithAllowUserAgentFilter` and `WithDenyUserAgentFilter` ->   `WithAllowUserAgent` and `WithDenyUserAgent`
to be consistent with `WithAllowCIDR`/`WithDenyCIDR` / Use less text for