### PR TITLE
online_test: close response body; enable bodyclose linter

### DIFF
--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -5,7 +5,7 @@ fmt:
 
 .PHONY: lint
 lint:
-	golangci-lint run .
+	golangci-lint run --enable=bodyclose .
 
 .PHONY: test
 test:


### PR DESCRIPTION
This PR modifies online tests by adding code that closes the response body to prevent resource leaks. Additionally, we enable `bodyclose` linter to automatically catch those mistakes.

From the [documentation](https://pkg.go.dev/net/http):
> The caller must close the response body when finished with it

Also, see this [article](https://golang50shad.es/index.html#close_http_resp_body) for a deep dive into the problem.