### PR TITLE
config: replace labelsPtr, stringPtr with ptr in tests

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -19,12 +19,8 @@ func assertSlice[T any](opts []any) []T {
 	return out
 }
 
-func labelPtr(labels map[string]*string) *map[string]*string {
-	return &labels
-}
-
-func stringPtr(s string) *string {
-	return &s
+func ptr[T any](val T) *T {
+	return &val
 }
 
 type matchBindExtra struct {

--- a/config/forwards_to_test.go
+++ b/config/forwards_to_test.go
@@ -15,12 +15,12 @@ func testForwardsTo[T tunnelConfigPrivate, OT any](t *testing.T,
 		{
 			name:             "absent",
 			opts:             optsFunc(),
-			expectForwardsTo: stringPtr(defaultForwardsTo()),
+			expectForwardsTo: ptr(defaultForwardsTo()),
 		},
 		{
 			name:             "with forwardsTo",
 			opts:             optsFunc(WithForwardsTo("localhost:8080")),
-			expectForwardsTo: stringPtr("localhost:8080"),
+			expectForwardsTo: ptr("localhost:8080"),
 		},
 	}
 

--- a/config/http_test.go
+++ b/config/http_test.go
@@ -13,8 +13,8 @@ func TestHTTP(t *testing.T) {
 		{
 			name:         "empty",
 			opts:         HTTPEndpoint(),
-			expectProto:  stringPtr("https"),
-			expectLabels: labelPtr(nil),
+			expectProto:  ptr("https"),
+			expectLabels: nil,
 			expectOpts: func(t *testing.T, opts *proto.HTTPEndpoint) {
 				require.NotNil(t, opts)
 			},

--- a/config/labeled_test.go
+++ b/config/labeled_test.go
@@ -11,10 +11,10 @@ func TestLabeled(t *testing.T) {
 		{
 			name: "simple",
 			opts: LabeledTunnel(WithLabel("foo", "bar")),
-			expectLabels: labelPtr(map[string]*string{
-				"foo": stringPtr("bar"),
+			expectLabels: ptr(map[string]*string{
+				"foo": ptr("bar"),
 			}),
-			expectProto:   stringPtr(""),
+			expectProto:   ptr(""),
 			expectNilOpts: true,
 		},
 		{
@@ -23,33 +23,33 @@ func TestLabeled(t *testing.T) {
 				WithLabel("foo", "bar"),
 				WithLabel("spam", "eggs"),
 			),
-			expectProto: stringPtr(""),
-			expectLabels: labelPtr(map[string]*string{
-				"foo":  stringPtr("bar"),
-				"spam": stringPtr("eggs"),
+			expectProto: ptr(""),
+			expectLabels: ptr(map[string]*string{
+				"foo":  ptr("bar"),
+				"spam": ptr("eggs"),
 			}),
 			expectNilOpts: true,
 		},
 		{
 			name: "withForwardsTo",
 			opts: LabeledTunnel(WithLabel("foo", "bar"), WithForwardsTo("localhost:8080")),
-			expectLabels: labelPtr(map[string]*string{
-				"foo": stringPtr("bar"),
+			expectLabels: ptr(map[string]*string{
+				"foo": ptr("bar"),
 			}),
-			expectForwardsTo: stringPtr("localhost:8080"),
-			expectProto:      stringPtr(""),
+			expectForwardsTo: ptr("localhost:8080"),
+			expectProto:      ptr(""),
 			expectNilOpts:    true,
 		},
 		{
 			name: "withMetadata",
 			opts: LabeledTunnel(WithLabel("foo", "bar"), WithMetadata("choochoo")),
-			expectLabels: labelPtr(map[string]*string{
-				"foo": stringPtr("bar"),
+			expectLabels: ptr(map[string]*string{
+				"foo": ptr("bar"),
 			}),
 			expectExtra: &matchBindExtra{
-				Metadata: stringPtr("choochoo"),
+				Metadata: ptr("choochoo"),
 			},
-			expectProto:   stringPtr(""),
+			expectProto:   ptr(""),
 			expectNilOpts: true,
 		},
 	}

--- a/config/metadata_test.go
+++ b/config/metadata_test.go
@@ -16,14 +16,14 @@ func testMetadata[T tunnelConfigPrivate, OT any](t *testing.T,
 			name: "absent",
 			opts: optsFunc(),
 			expectExtra: &matchBindExtra{
-				Metadata: stringPtr(""),
+				Metadata: ptr(""),
 			},
 		},
 		{
 			name: "with metadata",
 			opts: optsFunc(WithMetadata("Hello, world!")),
 			expectExtra: &matchBindExtra{
-				Metadata: stringPtr("Hello, world!"),
+				Metadata: ptr("Hello, world!"),
 			},
 		},
 	}

--- a/config/scheme_test.go
+++ b/config/scheme_test.go
@@ -11,17 +11,17 @@ func TestScheme(t *testing.T) {
 		{
 			name:        "default",
 			opts:        HTTPEndpoint(),
-			expectProto: stringPtr(string(SchemeHTTPS)),
+			expectProto: ptr(string(SchemeHTTPS)),
 		},
 		{
 			name:        "set https",
 			opts:        HTTPEndpoint(WithScheme(SchemeHTTPS)),
-			expectProto: stringPtr(string(SchemeHTTPS)),
+			expectProto: ptr(string(SchemeHTTPS)),
 		},
 		{
 			name:        "force http",
 			opts:        HTTPEndpoint(WithScheme(SchemeHTTP)),
-			expectProto: stringPtr(string(SchemeHTTP)),
+			expectProto: ptr(string(SchemeHTTP)),
 		},
 	}
 

--- a/config/tcp_test.go
+++ b/config/tcp_test.go
@@ -13,8 +13,8 @@ func TestTCP(t *testing.T) {
 		{
 			name:         "empty",
 			opts:         TCPEndpoint(),
-			expectProto:  stringPtr("tcp"),
-			expectLabels: labelPtr(nil),
+			expectProto:  ptr("tcp"),
+			expectLabels: nil,
 			expectOpts: func(t *testing.T, opts *proto.TCPEndpoint) {
 				require.NotNil(t, opts)
 				require.Empty(t, opts.Addr)
@@ -23,8 +23,8 @@ func TestTCP(t *testing.T) {
 		{
 			name:         "remote addr",
 			opts:         TCPEndpoint(WithRemoteAddr("0.tcp.ngrok.io:1234")),
-			expectProto:  stringPtr("tcp"),
-			expectLabels: labelPtr(nil),
+			expectProto:  ptr("tcp"),
+			expectLabels: nil,
 			expectOpts: func(t *testing.T, opts *proto.TCPEndpoint) {
 				require.NotNil(t, opts)
 				require.Equal(t, "0.tcp.ngrok.io:1234", opts.Addr)

--- a/config/tls_test.go
+++ b/config/tls_test.go
@@ -11,8 +11,8 @@ func TestTLS(t *testing.T) {
 		{
 			name:         "basic",
 			opts:         TLSEndpoint(),
-			expectProto:  stringPtr("tls"),
-			expectLabels: labelPtr(nil),
+			expectProto:  ptr("tls"),
+			expectLabels: nil,
 		},
 	}
 


### PR DESCRIPTION
This PR simplifies tests in the `config` package.