### PR TITLE
test: refactor asserts

### DIFF
--- a/config/cidr_restrictions_test.go
+++ b/config/cidr_restrictions_test.go
@@ -32,8 +32,7 @@ func testCIDRRestrictions[T tunnelConfigPrivate, O any, OT any](t *testing.T,
 			expectOpts: func(t *testing.T, opts *O) {
 				actual := getRestrictions(opts)
 				require.NotNil(t, actual)
-				require.Len(t, actual.AllowCidrs, 1)
-				require.Contains(t, actual.AllowCidrs, "127.0.0.0/8")
+				require.Equal(t, []string{"127.0.0.0/8"}, actual.AllowCidrs)
 			},
 		},
 		{
@@ -42,8 +41,7 @@ func testCIDRRestrictions[T tunnelConfigPrivate, O any, OT any](t *testing.T,
 			expectOpts: func(t *testing.T, opts *O) {
 				actual := getRestrictions(opts)
 				require.NotNil(t, actual)
-				require.Len(t, actual.DenyCidrs, 1)
-				require.Contains(t, actual.DenyCidrs, "127.0.0.0/8")
+				require.Equal(t, []string{"127.0.0.0/8"}, actual.DenyCidrs)
 			},
 		},
 		{
@@ -52,8 +50,7 @@ func testCIDRRestrictions[T tunnelConfigPrivate, O any, OT any](t *testing.T,
 			expectOpts: func(t *testing.T, opts *O) {
 				actual := getRestrictions(opts)
 				require.NotNil(t, actual)
-				require.Len(t, actual.AllowCidrs, 1)
-				require.Contains(t, actual.AllowCidrs, "127.0.0.0/8")
+				require.Equal(t, []string{"127.0.0.0/8"}, actual.AllowCidrs)
 			},
 		},
 		{
@@ -62,8 +59,7 @@ func testCIDRRestrictions[T tunnelConfigPrivate, O any, OT any](t *testing.T,
 			expectOpts: func(t *testing.T, opts *O) {
 				actual := getRestrictions(opts)
 				require.NotNil(t, actual)
-				require.Len(t, actual.DenyCidrs, 1)
-				require.Contains(t, actual.DenyCidrs, "127.0.0.0/8")
+				require.Equal(t, []string{"127.0.0.0/8"}, actual.DenyCidrs)
 			},
 		},
 		{
@@ -75,9 +71,7 @@ func testCIDRRestrictions[T tunnelConfigPrivate, O any, OT any](t *testing.T,
 			expectOpts: func(t *testing.T, opts *O) {
 				actual := getRestrictions(opts)
 				require.NotNil(t, actual)
-				require.Len(t, actual.AllowCidrs, 2)
-				require.Contains(t, actual.AllowCidrs, "127.0.0.0/8")
-				require.Contains(t, actual.AllowCidrs, "10.0.0.0/8")
+				require.ElementsMatch(t, []string{"127.0.0.0/8", "10.0.0.0/8"}, actual.AllowCidrs)
 			},
 		},
 		{
@@ -89,9 +83,7 @@ func testCIDRRestrictions[T tunnelConfigPrivate, O any, OT any](t *testing.T,
 			expectOpts: func(t *testing.T, opts *O) {
 				actual := getRestrictions(opts)
 				require.NotNil(t, actual)
-				require.Len(t, actual.DenyCidrs, 2)
-				require.Contains(t, actual.DenyCidrs, "127.0.0.0/8")
-				require.Contains(t, actual.DenyCidrs, "10.0.0.0/8")
+				require.ElementsMatch(t, []string{"127.0.0.0/8", "10.0.0.0/8"}, actual.DenyCidrs)
 			},
 		},
 		{
@@ -105,12 +97,8 @@ func testCIDRRestrictions[T tunnelConfigPrivate, O any, OT any](t *testing.T,
 			expectOpts: func(t *testing.T, opts *O) {
 				actual := getRestrictions(opts)
 				require.NotNil(t, actual)
-				require.Len(t, actual.DenyCidrs, 2)
-				require.Contains(t, actual.DenyCidrs, "192.0.0.0/8")
-				require.Contains(t, actual.DenyCidrs, "172.0.0.0/8")
-				require.Len(t, actual.AllowCidrs, 2)
-				require.Contains(t, actual.AllowCidrs, "127.0.0.0/8")
-				require.Contains(t, actual.AllowCidrs, "10.0.0.0/8")
+				require.ElementsMatch(t, []string{"192.0.0.0/8", "172.0.0.0/8"}, actual.DenyCidrs)
+				require.ElementsMatch(t, []string{"127.0.0.0/8", "10.0.0.0/8"}, actual.AllowCidrs)
 			},
 		},
 		{
@@ -124,12 +112,8 @@ func testCIDRRestrictions[T tunnelConfigPrivate, O any, OT any](t *testing.T,
 			expectOpts: func(t *testing.T, opts *O) {
 				actual := getRestrictions(opts)
 				require.NotNil(t, actual)
-				require.Len(t, actual.DenyCidrs, 2)
-				require.Contains(t, actual.DenyCidrs, "192.0.0.0/8")
-				require.Contains(t, actual.DenyCidrs, "172.0.0.0/8")
-				require.Len(t, actual.AllowCidrs, 2)
-				require.Contains(t, actual.AllowCidrs, "127.0.0.0/8")
-				require.Contains(t, actual.AllowCidrs, "10.0.0.0/8")
+				require.ElementsMatch(t, []string{"192.0.0.0/8", "172.0.0.0/8"}, actual.DenyCidrs)
+				require.ElementsMatch(t, []string{"127.0.0.0/8", "10.0.0.0/8"}, actual.AllowCidrs)
 			},
 		},
 	}

--- a/config/http_headers_test.go
+++ b/config/http_headers_test.go
@@ -34,8 +34,8 @@ func TestHTTPHeaders(t *testing.T) {
 				require.NotNil(t, req)
 				require.Nil(t, resp)
 
-				require.Contains(t, req.Add, "foo:bar baz")
-				require.Contains(t, req.Remove, "baz")
+				require.Equal(t, []string{"foo:bar baz"}, req.Add)
+				require.Equal(t, []string{"baz"}, req.Remove)
 			},
 		},
 		{
@@ -54,10 +54,8 @@ func TestHTTPHeaders(t *testing.T) {
 				require.NotNil(t, req)
 				require.Nil(t, resp)
 
-				require.Contains(t, req.Add, "foo:bar;baz")
-				require.Contains(t, req.Add, "spam:eggs")
-				require.Contains(t, req.Remove, "qas")
-				require.Contains(t, req.Remove, "wex")
+				require.ElementsMatch(t, []string{"foo:bar;baz", "spam:eggs"}, req.Add)
+				require.ElementsMatch(t, []string{"qas", "wex"}, req.Remove)
 			},
 		},
 		{
@@ -73,8 +71,8 @@ func TestHTTPHeaders(t *testing.T) {
 				require.Nil(t, req)
 				require.NotNil(t, resp)
 
-				require.Contains(t, resp.Add, "foo:bar baz")
-				require.Contains(t, resp.Remove, "baz")
+				require.Equal(t, []string{"foo:bar baz"}, resp.Add)
+				require.Equal(t, []string{"baz"}, resp.Remove)
 			},
 		},
 		{
@@ -92,10 +90,8 @@ func TestHTTPHeaders(t *testing.T) {
 				require.Nil(t, req)
 				require.NotNil(t, resp)
 
-				require.Contains(t, resp.Add, "foo:bar baz")
-				require.Contains(t, resp.Add, "spam:eggs")
-				require.Contains(t, resp.Remove, "qas")
-				require.Contains(t, resp.Remove, "wex")
+				require.ElementsMatch(t, []string{"foo:bar baz", "spam:eggs"}, resp.Add)
+				require.ElementsMatch(t, []string{"qas", "wex"}, resp.Remove)
 			},
 		},
 		{
@@ -117,14 +113,8 @@ func TestHTTPHeaders(t *testing.T) {
 				require.NotNil(t, req)
 				require.NotNil(t, resp)
 
-				require.Contains(t, req.Add, "foo:bar baz")
-				require.Contains(t, req.Add, "spam:eggs")
-				require.Contains(t, req.Remove, "qas")
-				require.Contains(t, req.Remove, "wex")
-				require.Contains(t, resp.Add, "foo:bar baz")
-				require.Contains(t, resp.Add, "spam:eggs")
-				require.Contains(t, resp.Remove, "wex")
-				require.Contains(t, resp.Remove, "qas")
+				require.ElementsMatch(t, []string{"spam:eggs", "foo:bar baz"}, resp.Add)
+				require.ElementsMatch(t, []string{"qas", "wex"}, resp.Remove)
 			},
 		},
 	}

--- a/config/oauth_test.go
+++ b/config/oauth_test.go
@@ -43,19 +43,9 @@ func TestOAuth(t *testing.T) {
 				actual := opts.OAuth
 				require.NotNil(t, actual)
 				require.Equal(t, "google", actual.Provider)
-				require.Len(t, actual.Scopes, 3)
-				require.Contains(t, actual.Scopes, "foo")
-				require.Contains(t, actual.Scopes, "bar")
-				require.Contains(t, actual.Scopes, "baz")
-				require.Len(t, actual.AllowEmails, 3)
-				require.Contains(t, actual.AllowEmails, "user1@gmail.com")
-				require.Contains(t, actual.AllowEmails, "user2@gmail.com")
-				require.Contains(t, actual.AllowEmails, "user3@gmail.com")
-				require.Len(t, actual.AllowDomains, 4)
-				require.Contains(t, actual.AllowDomains, "ngrok.com")
-				require.Contains(t, actual.AllowDomains, "google.com")
-				require.Contains(t, actual.AllowDomains, "facebook.com")
-				require.Contains(t, actual.AllowDomains, "github.com")
+				require.ElementsMatch(t, []string{"foo", "bar", "baz"}, actual.Scopes)
+				require.ElementsMatch(t, []string{"user1@gmail.com", "user2@gmail.com", "user3@gmail.com"}, actual.AllowEmails)
+				require.ElementsMatch(t, []string{"ngrok.com", "google.com", "github.com", "facebook.com"}, actual.AllowDomains)
 			},
 		},
 	}

--- a/config/oidc_test.go
+++ b/config/oidc_test.go
@@ -44,18 +44,9 @@ func TestOIDC(t *testing.T) {
 			expectOpts: func(t *testing.T, opts *proto.HTTPEndpoint) {
 				actual := opts.OIDC
 				require.NotNil(t, actual)
-				require.Len(t, actual.Scopes, 3)
-				require.Contains(t, actual.Scopes, "foo")
-				require.Contains(t, actual.Scopes, "bar")
-				require.Contains(t, actual.Scopes, "baz")
-				require.Len(t, actual.AllowEmails, 3)
-				require.Contains(t, actual.AllowEmails, "user1@gmail.com")
-				require.Contains(t, actual.AllowEmails, "user2@gmail.com")
-				require.Contains(t, actual.AllowEmails, "user3@gmail.com")
-				require.Len(t, actual.AllowDomains, 3)
-				require.Contains(t, actual.AllowDomains, "ngrok.com")
-				require.Contains(t, actual.AllowDomains, "google.com")
-				require.Contains(t, actual.AllowDomains, "github.com")
+				require.ElementsMatch(t, []string{"foo", "bar", "baz"}, actual.Scopes)
+				require.ElementsMatch(t, []string{"user1@gmail.com", "user2@gmail.com", "user3@gmail.com"}, actual.AllowEmails)
+				require.ElementsMatch(t, []string{"ngrok.com", "google.com", "github.com"}, actual.AllowDomains)
 			},
 		},
 	}

--- a/config/user_agent_filter_test.go
+++ b/config/user_agent_filter_test.go
@@ -34,10 +34,8 @@ func testUserAgentFilter[T tunnelConfigPrivate, O any, OT any](t *testing.T,
 				actual := getUserAgentFilter(opts)
 				require.NotNil(t, actual)
 				require.Nil(t, actual.Deny)
-				require.NotNil(t, actual.Allow)
-				require.Len(t, actual.Allow, 1)
-				require.Len(t, actual.Deny, 0)
-				require.Contains(t, actual.Allow, `(Pingdom\.com_bot_version_)(\d+)\.(\d+)`)
+				require.Empty(t, actual.Deny)
+				require.Equal(t, []string{`(Pingdom\.com_bot_version_)(\d+)\.(\d+)`}, actual.Allow)
 			},
 		},
 		{
@@ -49,10 +47,7 @@ func testUserAgentFilter[T tunnelConfigPrivate, O any, OT any](t *testing.T,
 				actual := getUserAgentFilter(opts)
 				require.NotNil(t, actual)
 				require.Nil(t, actual.Allow)
-				require.Len(t, actual.Allow, 0)
-				require.NotNil(t, actual.Deny)
-				require.Len(t, actual.Deny, 1)
-				require.Contains(t, actual.Deny, `(Pingdom\.com_bot_version_)(\d+)\.(\d+)`)
+				require.Equal(t, []string{`(Pingdom\.com_bot_version_)(\d+)\.(\d+)`}, actual.Deny)
 			},
 		},
 		{
@@ -64,10 +59,8 @@ func testUserAgentFilter[T tunnelConfigPrivate, O any, OT any](t *testing.T,
 			expectOpts: func(t *testing.T, opts *O) {
 				actual := getUserAgentFilter(opts)
 				require.NotNil(t, actual)
-				require.Len(t, actual.Allow, 1)
-				require.Len(t, actual.Deny, 1)
-				require.Contains(t, actual.Allow, `(Pingdom\.com_bot_version_)(\d+)\.(\d+)`)
-				require.Contains(t, actual.Deny, `(Pingdom\.com_bot_version_)(\d+)\.(\d+)`)
+				require.Equal(t, []string{`(Pingdom\.com_bot_version_)(\d+)\.(\d+)`}, actual.Allow)
+				require.Equal(t, []string{`(Pingdom\.com_bot_version_)(\d+)\.(\d+)`}, actual.Deny)
 			},
 		},
 		{
@@ -81,12 +74,8 @@ func testUserAgentFilter[T tunnelConfigPrivate, O any, OT any](t *testing.T,
 			expectOpts: func(t *testing.T, opts *O) {
 				actual := getUserAgentFilter(opts)
 				require.NotNil(t, actual)
-				require.Len(t, actual.Allow, 2)
-				require.Len(t, actual.Deny, 2)
-				require.Contains(t, actual.Allow, `(Pingdom\.com_bot_version_)(\d+)\.(\d+)`)
-				require.Contains(t, actual.Deny, `(Pingdom\.com_bot_version_)(\d+)\.(\d+)`)
-				require.Contains(t, actual.Allow, `(Pingdom2\.com_bot_version_)(\d+)\.(\d+)`)
-				require.Contains(t, actual.Deny, `(Pingdom2\.com_bot_version_)(\d+)\.(\d+)`)
+				require.Equal(t, []string{`(Pingdom\.com_bot_version_)(\d+)\.(\d+)`, `(Pingdom2\.com_bot_version_)(\d+)\.(\d+)`}, actual.Allow)
+				require.Equal(t, []string{`(Pingdom\.com_bot_version_)(\d+)\.(\d+)`, `(Pingdom2\.com_bot_version_)(\d+)\.(\d+)`}, actual.Deny)
 			},
 		},
 	}

--- a/session_test.go
+++ b/session_test.go
@@ -8,15 +8,15 @@ import (
 
 func TestUserAgent(t *testing.T) {
 	s := (&clientInfo{Type: "library/official/go", Version: "1.2.3"}).ToUserAgent()
-	require.Equal(t, s, "library-official-go/1.2.3")
+	require.Equal(t, "library-official-go/1.2.3", s)
 
 	s = (&clientInfo{Type: "some@funky☺user agent", Version: "№1.2.3"}).ToUserAgent()
-	require.Equal(t, s, "some#funky#user#agent/#1.2.3")
+	require.Equal(t, "some#funky#user#agent/#1.2.3", s)
 
 	s = (&clientInfo{
 		Type:     "agent/official/go",
 		Version:  "3.2.1",
 		Comments: []string{"{\"ProxyType\": \"socks5\", \"ConfigVersion\": \"2\"}"},
 	}).ToUserAgent()
-	require.Equal(t, s, "agent-official-go/3.2.1 ({\"ProxyType\": \"socks5\", \"ConfigVersion\": \"2\"})")
+	require.Equal(t, "agent-official-go/3.2.1 ({\"ProxyType\": \"socks5\", \"ConfigVersion\": \"2\"})", s)
 }


### PR DESCRIPTION
This PR simplifies test asserts.

Changes:
- replace `require.Len+require.Contains` with `require.ElementsMatch` or `require.Equal`;
- replace `require.Equal(t, err.Error(), ...)` with `require.EqualError(t, err, ...)`;
- replace `require.True(t, errors.As(...))` with `require.ErrorAs(...)`;
- replace `require.Len(t, slice, 0)` with `require.Empty(t, slice)`;
- reverse actual and expected values in some asserts.