### PR TITLE
Add missing doc links and update broken ones

### DIFF
--- a/config/basic_auth.go
+++ b/config/basic_auth.go
@@ -20,6 +20,8 @@ func (ba basicAuth) toProtoConfig() *pb.MiddlewareConfiguration_BasicAuthCredent
 
 // WithBasicAuth adds the provided credentials to the list of basic
 // authentication credentials.
+//
+// https://ngrok.com/docs/http/basic-auth/
 func WithBasicAuth(username, password string) HTTPEndpointOption {
 	return httpOptionFunc(func(cfg *httpOptions) {
 		cfg.BasicAuth = append(cfg.BasicAuth,

--- a/config/cidr_restrictions.go
+++ b/config/cidr_restrictions.go
@@ -15,6 +15,8 @@ type cidrRestrictions struct {
 }
 
 // Add the provided CIDRS to the [CIDRRestriction].Allowed list.
+//
+// https://ngrok.com/docs/http/ip-restrictions/
 func WithAllowCIDRString(cidr ...string) interface {
 	HTTPEndpointOption
 	TCPEndpointOption
@@ -24,6 +26,8 @@ func WithAllowCIDRString(cidr ...string) interface {
 }
 
 // Add the provided [net.IPNet] to the [CIDRRestriction].Allowed list.
+//
+// https://ngrok.com/docs/http/ip-restrictions/
 func WithAllowCIDR(net ...*net.IPNet) interface {
 	HTTPEndpointOption
 	TCPEndpointOption
@@ -37,6 +41,8 @@ func WithAllowCIDR(net ...*net.IPNet) interface {
 }
 
 // Add the provided CIDRS to the [CIDRRestriction].Denied list.
+//
+// https://ngrok.com/docs/http/ip-restrictions/
 func WithDenyCIDRString(cidr ...string) interface {
 	HTTPEndpointOption
 	TCPEndpointOption
@@ -46,6 +52,8 @@ func WithDenyCIDRString(cidr ...string) interface {
 }
 
 // Add the provided [net.IPNet] to the [CIDRRestriction].Denied list.
+//
+// https://ngrok.com/docs/http/ip-restrictions/
 func WithDenyCIDR(net ...*net.IPNet) interface {
 	HTTPEndpointOption
 	TCPEndpointOption

--- a/config/circuit_breaker.go
+++ b/config/circuit_breaker.go
@@ -2,6 +2,8 @@ package config
 
 // WithCircuitBreaker sets the 5XX response ratio at which the ngrok edge will
 // stop sending requests to this tunnel.
+//
+// https://ngrok.com/docs/http/circuit-breaker/
 func WithCircuitBreaker(ratio float64) HTTPEndpointOption {
 	return httpOptionFunc(func(cfg *httpOptions) {
 		cfg.CircuitBreaker = ratio

--- a/config/compression.go
+++ b/config/compression.go
@@ -1,6 +1,8 @@
 package config
 
 // WithCompression enables gzip compression.
+//
+// https://ngrok.com/docs/http/compression/
 func WithCompression() HTTPEndpointOption {
 	return httpOptionFunc(func(cfg *httpOptions) {
 		cfg.Compression = true

--- a/config/domain.go
+++ b/config/domain.go
@@ -3,6 +3,8 @@ package config
 type domainOption string
 
 // WithDomain sets the fully-qualified domain name for this edge.
+//
+// https://ngrok.com/docs/network-edge/domains-and-tcp-addresses/#domains
 func WithDomain(name string) interface {
 	HTTPEndpointOption
 	TLSEndpointOption

--- a/config/forwards_to.go
+++ b/config/forwards_to.go
@@ -10,6 +10,8 @@ type forwardsToOption string
 
 // WithForwardsTo sets the ForwardsTo string for this tunnel.
 // This can be viewed via the API or dashboard.
+//
+// https://ngrok.com/docs/api/resources/tunnels/#tunnel-fields
 func WithForwardsTo(meta string) Options {
 	return forwardsToOption(meta)
 }

--- a/config/http.go
+++ b/config/http.go
@@ -19,6 +19,8 @@ func (of httpOptionFunc) ApplyHTTP(cfg *httpOptions) {
 }
 
 // HTTPEndpoint constructs a new set options for a HTTP endpoint.
+//
+// https://ngrok.com/docs/http/
 func HTTPEndpoint(opts ...HTTPEndpointOption) Tunnel {
 	cfg := httpOptions{}
 	for _, opt := range opts {

--- a/config/http_headers.go
+++ b/config/http_headers.go
@@ -63,6 +63,8 @@ func (h responseHeaders) ApplyHTTP(cfg *httpOptions) {
 }
 
 // WithRequestHeader adds a header to all requests to this edge.
+//
+// https://ngrok.com/docs/http/request-headers/
 func WithRequestHeader(name, value string) HTTPEndpointOption {
 	return requestHeaders(headers{
 		Added: map[string]string{name: value},
@@ -70,6 +72,8 @@ func WithRequestHeader(name, value string) HTTPEndpointOption {
 }
 
 // WithRequestHeader adds a header to all responses coming from this edge.
+//
+// https://ngrok.com/docs/http/response-headers/
 func WithResponseHeader(name, value string) HTTPEndpointOption {
 	return responseHeaders(headers{
 		Added: map[string]string{name: value},
@@ -77,6 +81,8 @@ func WithResponseHeader(name, value string) HTTPEndpointOption {
 }
 
 // WithRemoveRequestHeader removes a header from requests to this edge.
+//
+// https://ngrok.com/docs/http/request-headers/
 func WithRemoveRequestHeader(name string) HTTPEndpointOption {
 	return requestHeaders(headers{
 		Removed: []string{name},
@@ -84,6 +90,8 @@ func WithRemoveRequestHeader(name string) HTTPEndpointOption {
 }
 
 // WithRemoveResponseHeader removes a header from responses from this edge.
+//
+// https://ngrok.com/docs/http/response-headers/
 func WithRemoveResponseHeader(name string) HTTPEndpointOption {
 	return responseHeaders(headers{
 		Removed: []string{name},

--- a/config/labeled.go
+++ b/config/labeled.go
@@ -17,6 +17,8 @@ func (of labeledOptionFunc) ApplyLabeled(cfg *labeledOptions) {
 }
 
 // LabeledTunnel constructs a new set options for a labeled Edge.
+//
+// https://ngrok.com/docs/network-edge/edges/#tunnel-group
 func LabeledTunnel(opts ...LabeledTunnelOption) Tunnel {
 	cfg := labeledOptions{}
 	for _, opt := range opts {

--- a/config/mutual_tls.go
+++ b/config/mutual_tls.go
@@ -13,6 +13,8 @@ type mutualTLSEndpointOption []*x509.Certificate
 // authentication.
 // These will be used to authenticate client certificates for requests at the
 // ngrok edge.
+//
+// https://ngrok.com/docs/http/mutual-tls/
 func WithMutualTLSCA(certs ...*x509.Certificate) interface {
 	HTTPEndpointOption
 	TLSEndpointOption

--- a/config/oauth.go
+++ b/config/oauth.go
@@ -82,6 +82,8 @@ func (oauth *oauthOptions) toProtoConfig() *pb.MiddlewareConfiguration_OAuth {
 
 // WithOAuth configures this edge with the the given OAuth provider.
 // Overwrites any previously-set OAuth configuration.
+//
+// https://ngrok.com/docs/http/oauth/
 func WithOAuth(provider string, opts ...OAuthOption) HTTPEndpointOption {
 	return httpOptionFunc(func(cfg *httpOptions) {
 		oauth := oauthProvider(provider)

--- a/config/oidc.go
+++ b/config/oidc.go
@@ -33,6 +33,8 @@ func (oidc *oidcOptions) toProtoConfig() *pb.MiddlewareConfiguration_OIDC {
 
 // WithOIDC configures this edge with the the given OIDC provider.
 // Overwrites any previously-set OIDC configuration.
+//
+// https://ngrok.com/docs/http/openid-connect/
 func WithOIDC(issuerURL string, clientID string, clientSecret string, opts ...OIDCOption) HTTPEndpointOption {
 	return httpOptionFunc(func(cfg *httpOptions) {
 		oidc := &oidcOptions{

--- a/config/tcp.go
+++ b/config/tcp.go
@@ -17,6 +17,8 @@ func (of tcpOptionFunc) ApplyTCP(cfg *tcpOptions) {
 }
 
 // TCPEndpoint constructs a new set options for a TCP endpoint.
+//
+// https://ngrok.com/docs/tcp/
 func TCPEndpoint(opts ...TCPEndpointOption) Tunnel {
 	cfg := tcpOptions{}
 	for _, opt := range opts {

--- a/config/tls.go
+++ b/config/tls.go
@@ -19,6 +19,8 @@ func (of tlsOptionFunc) ApplyTLS(cfg *tlsOptions) {
 }
 
 // TLSEndpoint constructs a new set options for a TLS endpoint.
+//
+// https://ngrok.com/docs/tls/
 func TLSEndpoint(opts ...TLSEndpointOption) Tunnel {
 	cfg := tlsOptions{}
 	for _, opt := range opts {

--- a/config/tls_termination.go
+++ b/config/tls_termination.go
@@ -39,6 +39,8 @@ type TLSTerminationOption func(tt *tlsTermination)
 // WithTLSTermination arranges for incoming TLS connections to be automatically terminated.
 // The backend will then receive plaintext streams, rather than raw TLS connections.
 // Defaults to terminating TLS at the ngrok edge with an automatically-provisioned keypair.
+//
+// https://ngrok.com/docs/tls/tls-termination/
 func WithTLSTermination(opts ...TLSTerminationOption) TLSEndpointOption {
 	tt := tlsTermination{
 		location: TLSAtEdge,

--- a/config/user_agent_filter.go
+++ b/config/user_agent_filter.go
@@ -19,7 +19,7 @@ type userAgentFilter struct {
 //
 // Any invalid regular expression will result in an error when creating the tunnel.
 //
-// https://ngrok.com/docs/cloud-edge/modules/user-agent-filter
+// https://ngrok.com/docs/http/user-agent-filter/
 // ERR_NGROK_2090 for invalid allow/deny on connect.
 // ERR_NGROK_3211 The server does not authorize requests from your user-agent
 // ERR_NGROK_9022 Your account is not authorized to use user agent filtering.
@@ -37,7 +37,7 @@ func WithAllowUserAgent(allow ...string) HTTPEndpointOption {
 //
 // Any invalid regular expression will result in an error when creating the tunnel.
 //
-// https://ngrok.com/docs/cloud-edge/modules/user-agent-filter
+// https://ngrok.com/docs/http/user-agent-filter/
 // ERR_NGROK_2090 for invalid allow/deny on connect.
 // ERR_NGROK_3211 The server does not authorize requests from your user-agent
 // ERR_NGROK_9022 Your account is not authorized to use user agent filtering.

--- a/config/webhook_verification.go
+++ b/config/webhook_verification.go
@@ -24,6 +24,8 @@ func (wv *webhookVerification) toProtoConfig() *pb.MiddlewareConfiguration_Webho
 }
 
 // WithWebhookVerification configures webhook verification for this edge.
+//
+// https://ngrok.com/docs/http/webhook-verification/
 func WithWebhookVerification(provider string, secret string) HTTPEndpointOption {
 	return httpOptionFunc(func(cfg *httpOptions) {
 		cfg.WebhookVerification = &webhookVerification{

--- a/config/websocket_tcp_conversion.go
+++ b/config/websocket_tcp_conversion.go
@@ -1,6 +1,8 @@
 package config
 
 // WithWebsocketTCPConversion enables the websocket-to-tcp converter.
+//
+// https://ngrok.com/docs/http/websocket-tcp-converter/
 func WithWebsocketTCPConversion() HTTPEndpointOption {
 	return httpOptionFunc(func(cfg *httpOptions) {
 		cfg.WebsocketTCPConversion = true


### PR DESCRIPTION
~First pass at docs.~

~~There'll be another pass converting them all to permalinks, but this gets the~~
~~final destinations in place so that I can do a single perma pass after we get~~
~the OK on the permalinks themselves.~

All links should be correct as of this change. Since Product is going to handle redirects on the ngrok/ngrok-docs side, there won't be a permalinking pass after all.
