### PR TITLE
ngrok: add option to auto-rewrite the host header on ListenAndForward

### DIFF
--- a/config/basic_auth_test.go
+++ b/config/basic_auth_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestBasicAuth(t *testing.T) {
-	cases := testCases[httpOptions, proto.HTTPEndpoint]{
+	cases := testCases[*httpOptions, proto.HTTPEndpoint]{
 		{
 			name: "single",
 			opts: HTTPEndpoint(WithBasicAuth("foo", "bar")),

--- a/config/cidr_restrictions_test.go
+++ b/config/cidr_restrictions_test.go
@@ -122,15 +122,15 @@ func testCIDRRestrictions[T tunnelConfigPrivate, O any, OT any](t *testing.T,
 }
 
 func TestCIDRRestrictions(t *testing.T) {
-	testCIDRRestrictions[httpOptions](t, HTTPEndpoint,
+	testCIDRRestrictions[*httpOptions](t, HTTPEndpoint,
 		func(h *proto.HTTPEndpoint) *pb.MiddlewareConfiguration_IPRestriction {
 			return h.IPRestriction
 		})
-	testCIDRRestrictions[tcpOptions](t, TCPEndpoint,
+	testCIDRRestrictions[*tcpOptions](t, TCPEndpoint,
 		func(h *proto.TCPEndpoint) *pb.MiddlewareConfiguration_IPRestriction {
 			return h.IPRestriction
 		})
-	testCIDRRestrictions[tlsOptions](t, TLSEndpoint,
+	testCIDRRestrictions[*tlsOptions](t, TLSEndpoint,
 		func(h *proto.TLSEndpoint) *pb.MiddlewareConfiguration_IPRestriction {
 			return h.IPRestriction
 		})

--- a/config/circuit_breaker_test.go
+++ b/config/circuit_breaker_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestCircuitBreaker(t *testing.T) {
-	cases := testCases[httpOptions, proto.HTTPEndpoint]{
+	cases := testCases[*httpOptions, proto.HTTPEndpoint]{
 		{
 			name: "absent",
 			opts: HTTPEndpoint(),

--- a/config/common.go
+++ b/config/common.go
@@ -31,4 +31,4 @@ func (cfg *commonOpts) getForwardsTo() string {
 	return cfg.ForwardsTo
 }
 
-func (cfg commonOpts) tunnelOptions() {}
+func (cfg *commonOpts) tunnelOptions() {}

--- a/config/compression_test.go
+++ b/config/compression_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestCompression(t *testing.T) {
-	cases := testCases[httpOptions, proto.HTTPEndpoint]{
+	cases := testCases[*httpOptions, proto.HTTPEndpoint]{
 		{
 			name: "absent",
 			opts: HTTPEndpoint(),

--- a/config/domain_test.go
+++ b/config/domain_test.go
@@ -40,10 +40,10 @@ func testDomain[T tunnelConfigPrivate, O any, OT any](t *testing.T,
 }
 
 func TestDomain(t *testing.T) {
-	testDomain[httpOptions](t, HTTPEndpoint, func(opts *proto.HTTPEndpoint) string {
+	testDomain[*httpOptions](t, HTTPEndpoint, func(opts *proto.HTTPEndpoint) string {
 		return opts.Domain
 	})
-	testDomain[tlsOptions](t, TLSEndpoint, func(opts *proto.TLSEndpoint) string {
+	testDomain[*tlsOptions](t, TLSEndpoint, func(opts *proto.TLSEndpoint) string {
 		return opts.Domain
 	})
 }

--- a/config/forwards_to_test.go
+++ b/config/forwards_to_test.go
@@ -28,8 +28,8 @@ func testForwardsTo[T tunnelConfigPrivate, OT any](t *testing.T,
 }
 
 func TestForwardsTo(t *testing.T) {
-	testForwardsTo[httpOptions](t, HTTPEndpoint)
-	testForwardsTo[tlsOptions](t, TLSEndpoint)
-	testForwardsTo[tcpOptions](t, TCPEndpoint)
-	testForwardsTo[labeledOptions](t, LabeledTunnel)
+	testForwardsTo[*httpOptions](t, HTTPEndpoint)
+	testForwardsTo[*tlsOptions](t, TLSEndpoint)
+	testForwardsTo[*tcpOptions](t, TCPEndpoint)
+	testForwardsTo[*labeledOptions](t, LabeledTunnel)
 }

--- a/config/http_headers.go
+++ b/config/http_headers.go
@@ -62,6 +62,18 @@ func (h responseHeaders) ApplyHTTP(cfg *httpOptions) {
 	cfg.ResponseHeaders = cfg.ResponseHeaders.merge(headers(h))
 }
 
+// WithHostHeaderRewrite will automatically set the `Host` header to the one in
+// the URL passed to `ListenAndForward`. Does nothing if using `Listen`.
+// Defaults to `false`.
+//
+// If you need to set the host header to a specific value, use
+// `WithRequestHeader("host", "some.host.com")` instead.
+func WithHostHeaderRewrite(rewrite bool) HTTPEndpointOption {
+	return httpOptionFunc(func(cfg *httpOptions) {
+		cfg.RewriteHostHeader = rewrite
+	})
+}
+
 // WithRequestHeader adds a header to all requests to this edge.
 func WithRequestHeader(name, value string) HTTPEndpointOption {
 	return requestHeaders(headers{

--- a/config/http_headers.go
+++ b/config/http_headers.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"net/http"
 
 	"golang.ngrok.com/ngrok/internal/pb"
 )
@@ -77,27 +78,27 @@ func WithHostHeaderRewrite(rewrite bool) HTTPEndpointOption {
 // WithRequestHeader adds a header to all requests to this edge.
 func WithRequestHeader(name, value string) HTTPEndpointOption {
 	return requestHeaders(headers{
-		Added: map[string]string{name: value},
+		Added: map[string]string{http.CanonicalHeaderKey(name): value},
 	})
 }
 
 // WithRequestHeader adds a header to all responses coming from this edge.
 func WithResponseHeader(name, value string) HTTPEndpointOption {
 	return responseHeaders(headers{
-		Added: map[string]string{name: value},
+		Added: map[string]string{http.CanonicalHeaderKey(name): value},
 	})
 }
 
 // WithRemoveRequestHeader removes a header from requests to this edge.
 func WithRemoveRequestHeader(name string) HTTPEndpointOption {
 	return requestHeaders(headers{
-		Removed: []string{name},
+		Removed: []string{http.CanonicalHeaderKey(name)},
 	})
 }
 
 // WithRemoveResponseHeader removes a header from responses from this edge.
 func WithRemoveResponseHeader(name string) HTTPEndpointOption {
 	return responseHeaders(headers{
-		Removed: []string{name},
+		Removed: []string{http.CanonicalHeaderKey(name)},
 	})
 }

--- a/config/http_headers_test.go
+++ b/config/http_headers_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestHTTPHeaders(t *testing.T) {
-	cases := testCases[httpOptions, proto.HTTPEndpoint]{
+	cases := testCases[*httpOptions, proto.HTTPEndpoint]{
 		{
 			name: "absent",
 			opts: HTTPEndpoint(),

--- a/config/http_headers_test.go
+++ b/config/http_headers_test.go
@@ -34,8 +34,8 @@ func TestHTTPHeaders(t *testing.T) {
 				require.NotNil(t, req)
 				require.Nil(t, resp)
 
-				require.Equal(t, []string{"foo:bar baz"}, req.Add)
-				require.Equal(t, []string{"baz"}, req.Remove)
+				require.Equal(t, []string{"Foo:bar baz"}, req.Add)
+				require.Equal(t, []string{"Baz"}, req.Remove)
 			},
 		},
 		{
@@ -54,8 +54,8 @@ func TestHTTPHeaders(t *testing.T) {
 				require.NotNil(t, req)
 				require.Nil(t, resp)
 
-				require.ElementsMatch(t, []string{"foo:bar;baz", "spam:eggs"}, req.Add)
-				require.ElementsMatch(t, []string{"qas", "wex"}, req.Remove)
+				require.ElementsMatch(t, []string{"Foo:bar;baz", "Spam:eggs"}, req.Add)
+				require.ElementsMatch(t, []string{"Qas", "Wex"}, req.Remove)
 			},
 		},
 		{
@@ -71,8 +71,8 @@ func TestHTTPHeaders(t *testing.T) {
 				require.Nil(t, req)
 				require.NotNil(t, resp)
 
-				require.Equal(t, []string{"foo:bar baz"}, resp.Add)
-				require.Equal(t, []string{"baz"}, resp.Remove)
+				require.Equal(t, []string{"Foo:bar baz"}, resp.Add)
+				require.Equal(t, []string{"Baz"}, resp.Remove)
 			},
 		},
 		{
@@ -90,8 +90,8 @@ func TestHTTPHeaders(t *testing.T) {
 				require.Nil(t, req)
 				require.NotNil(t, resp)
 
-				require.ElementsMatch(t, []string{"foo:bar baz", "spam:eggs"}, resp.Add)
-				require.ElementsMatch(t, []string{"qas", "wex"}, resp.Remove)
+				require.ElementsMatch(t, []string{"Foo:bar baz", "Spam:eggs"}, resp.Add)
+				require.ElementsMatch(t, []string{"Qas", "Wex"}, resp.Remove)
 			},
 		},
 		{
@@ -113,8 +113,8 @@ func TestHTTPHeaders(t *testing.T) {
 				require.NotNil(t, req)
 				require.NotNil(t, resp)
 
-				require.ElementsMatch(t, []string{"spam:eggs", "foo:bar baz"}, resp.Add)
-				require.ElementsMatch(t, []string{"qas", "wex"}, resp.Remove)
+				require.ElementsMatch(t, []string{"Spam:eggs", "Foo:bar baz"}, resp.Add)
+				require.ElementsMatch(t, []string{"Qas", "Wex"}, resp.Remove)
 			},
 		},
 	}

--- a/config/http_test.go
+++ b/config/http_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestHTTP(t *testing.T) {
-	cases := testCases[httpOptions, proto.HTTPEndpoint]{
+	cases := testCases[*httpOptions, proto.HTTPEndpoint]{
 		{
 			name:         "empty",
 			opts:         HTTPEndpoint(),

--- a/config/labeled.go
+++ b/config/labeled.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"net/http"
+	"net/url"
 
 	"golang.ngrok.com/ngrok/internal/tunnel/proto"
 )
@@ -22,7 +23,7 @@ func LabeledTunnel(opts ...LabeledTunnelOption) Tunnel {
 	for _, opt := range opts {
 		opt.ApplyLabeled(&cfg)
 	}
-	return cfg
+	return &cfg
 }
 
 // Options for labeled tunnels.
@@ -53,8 +54,8 @@ func (cfg labeledOptions) ForwardsTo() string {
 	return cfg.commonOpts.getForwardsTo()
 }
 
-func (cfg labeledOptions) WithForwardsTo(hostname string) {
-	cfg.commonOpts.ForwardsTo = hostname
+func (cfg *labeledOptions) WithForwardsTo(url *url.URL) {
+	cfg.commonOpts.ForwardsTo = url.Host
 }
 
 func (cfg labeledOptions) Extra() proto.BindExtra {

--- a/config/labeled_test.go
+++ b/config/labeled_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestLabeled(t *testing.T) {
-	cases := testCases[labeledOptions, proto.LabelOptions]{
+	cases := testCases[*labeledOptions, proto.LabelOptions]{
 		{
 			name: "simple",
 			opts: LabeledTunnel(WithLabel("foo", "bar")),

--- a/config/metadata_test.go
+++ b/config/metadata_test.go
@@ -32,8 +32,8 @@ func testMetadata[T tunnelConfigPrivate, OT any](t *testing.T,
 }
 
 func TestMetadata(t *testing.T) {
-	testMetadata[httpOptions](t, HTTPEndpoint)
-	testMetadata[tlsOptions](t, TLSEndpoint)
-	testMetadata[tcpOptions](t, TCPEndpoint)
-	testMetadata[labeledOptions](t, LabeledTunnel)
+	testMetadata[*httpOptions](t, HTTPEndpoint)
+	testMetadata[*tlsOptions](t, TLSEndpoint)
+	testMetadata[*tcpOptions](t, TCPEndpoint)
+	testMetadata[*labeledOptions](t, LabeledTunnel)
 }

--- a/config/mutual_tls_test.go
+++ b/config/mutual_tls_test.go
@@ -54,10 +54,10 @@ func testMutualTLS[T tunnelConfigPrivate, O any, OT any](t *testing.T,
 }
 
 func TestMutualTLS(t *testing.T) {
-	testMutualTLS[httpOptions](t, HTTPEndpoint, func(opts *proto.HTTPEndpoint) *pb.MiddlewareConfiguration_MutualTLS {
+	testMutualTLS[*httpOptions](t, HTTPEndpoint, func(opts *proto.HTTPEndpoint) *pb.MiddlewareConfiguration_MutualTLS {
 		return opts.MutualTLSCA
 	})
-	testMutualTLS[tlsOptions](t, TLSEndpoint, func(opts *proto.TLSEndpoint) *pb.MiddlewareConfiguration_MutualTLS {
+	testMutualTLS[*tlsOptions](t, TLSEndpoint, func(opts *proto.TLSEndpoint) *pb.MiddlewareConfiguration_MutualTLS {
 		return opts.MutualTLSAtEdge
 	})
 }

--- a/config/oauth_test.go
+++ b/config/oauth_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestOAuth(t *testing.T) {
-	cases := testCases[httpOptions, proto.HTTPEndpoint]{
+	cases := testCases[*httpOptions, proto.HTTPEndpoint]{
 		{
 			name: "absent",
 			opts: HTTPEndpoint(),

--- a/config/oidc_test.go
+++ b/config/oidc_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestOIDC(t *testing.T) {
-	cases := testCases[httpOptions, proto.HTTPEndpoint]{
+	cases := testCases[*httpOptions, proto.HTTPEndpoint]{
 		{
 			name: "absent",
 			opts: HTTPEndpoint(),

--- a/config/proxy_proto_test.go
+++ b/config/proxy_proto_test.go
@@ -41,13 +41,13 @@ func testProxyProto[T tunnelConfigPrivate, O any, OT any](t *testing.T,
 }
 
 func TestProxyProto(t *testing.T) {
-	testProxyProto[httpOptions](t, HTTPEndpoint, func(opts *proto.HTTPEndpoint) proto.ProxyProto {
+	testProxyProto[*httpOptions](t, HTTPEndpoint, func(opts *proto.HTTPEndpoint) proto.ProxyProto {
 		return opts.ProxyProto
 	})
-	testProxyProto[tlsOptions](t, TLSEndpoint, func(opts *proto.TLSEndpoint) proto.ProxyProto {
+	testProxyProto[*tlsOptions](t, TLSEndpoint, func(opts *proto.TLSEndpoint) proto.ProxyProto {
 		return opts.ProxyProto
 	})
-	testProxyProto[tcpOptions](t, TCPEndpoint, func(opts *proto.TCPEndpoint) proto.ProxyProto {
+	testProxyProto[*tcpOptions](t, TCPEndpoint, func(opts *proto.TCPEndpoint) proto.ProxyProto {
 		return opts.ProxyProto
 	})
 }

--- a/config/scheme_test.go
+++ b/config/scheme_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestScheme(t *testing.T) {
-	cases := testCases[httpOptions, proto.HTTPEndpoint]{
+	cases := testCases[*httpOptions, proto.HTTPEndpoint]{
 		{
 			name:        "default",
 			opts:        HTTPEndpoint(),

--- a/config/tcp.go
+++ b/config/tcp.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"net/http"
+	"net/url"
 
 	"golang.ngrok.com/ngrok/internal/tunnel/proto"
 )
@@ -22,7 +23,7 @@ func TCPEndpoint(opts ...TCPEndpointOption) Tunnel {
 	for _, opt := range opts {
 		opt.ApplyTCP(&cfg)
 	}
-	return cfg
+	return &cfg
 }
 
 // The options for a TCP edge.
@@ -55,8 +56,8 @@ func (cfg tcpOptions) ForwardsTo() string {
 	return cfg.commonOpts.getForwardsTo()
 }
 
-func (cfg tcpOptions) WithForwardsTo(hostname string) {
-	cfg.commonOpts.ForwardsTo = hostname
+func (cfg *tcpOptions) WithForwardsTo(url *url.URL) {
+	cfg.commonOpts.ForwardsTo = url.Host
 }
 
 func (cfg tcpOptions) Extra() proto.BindExtra {

--- a/config/tcp_test.go
+++ b/config/tcp_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestTCP(t *testing.T) {
-	cases := testCases[tcpOptions, proto.TCPEndpoint]{
+	cases := testCases[*tcpOptions, proto.TCPEndpoint]{
 		{
 			name:         "empty",
 			opts:         TCPEndpoint(),

--- a/config/tls.go
+++ b/config/tls.go
@@ -3,6 +3,7 @@ package config
 import (
 	"crypto/x509"
 	"net/http"
+	"net/url"
 
 	"golang.ngrok.com/ngrok/internal/pb"
 	"golang.ngrok.com/ngrok/internal/tunnel/proto"
@@ -24,7 +25,7 @@ func TLSEndpoint(opts ...TLSEndpointOption) Tunnel {
 	for _, opt := range opts {
 		opt.ApplyTLS(&cfg)
 	}
-	return cfg
+	return &cfg
 }
 
 // The options for TLS edges.
@@ -85,8 +86,8 @@ func (cfg tlsOptions) ForwardsTo() string {
 	return cfg.commonOpts.getForwardsTo()
 }
 
-func (cfg tlsOptions) WithForwardsTo(hostname string) {
-	cfg.commonOpts.ForwardsTo = hostname
+func (cfg *tlsOptions) WithForwardsTo(url *url.URL) {
+	cfg.commonOpts.ForwardsTo = url.Host
 }
 
 func (cfg tlsOptions) Extra() proto.BindExtra {

--- a/config/tls_termination_test.go
+++ b/config/tls_termination_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestTLSTermination(t *testing.T) {
-	cases := testCases[tlsOptions, proto.TLSEndpoint]{
+	cases := testCases[*tlsOptions, proto.TLSEndpoint]{
 		{
 			name: "absent",
 			opts: TLSEndpoint(),

--- a/config/tls_test.go
+++ b/config/tls_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestTLS(t *testing.T) {
-	cases := testCases[tlsOptions, proto.TLSEndpoint]{
+	cases := testCases[*tlsOptions, proto.TLSEndpoint]{
 		{
 			name:         "basic",
 			opts:         TLSEndpoint(),

--- a/config/tunnel_config.go
+++ b/config/tunnel_config.go
@@ -1,6 +1,10 @@
 package config
 
-import "golang.ngrok.com/ngrok/internal/tunnel/proto"
+import (
+	"net/url"
+
+	"golang.ngrok.com/ngrok/internal/tunnel/proto"
+)
 
 // Tunnel is a marker interface for options that can be used to start
 // tunnels.
@@ -14,9 +18,11 @@ type Tunnel interface {
 // the public interface with internal details.
 type tunnelConfigPrivate interface {
 	ForwardsTo() string
-	WithForwardsTo(string)
 	Extra() proto.BindExtra
 	Proto() string
 	Opts() any
 	Labels() map[string]string
+	// Extra config when auto-forwarding to a URL.
+	// Normal operation should use the functional builder.
+	WithForwardsTo(*url.URL)
 }

--- a/config/user_agent_filter_test.go
+++ b/config/user_agent_filter_test.go
@@ -84,7 +84,7 @@ func testUserAgentFilter[T tunnelConfigPrivate, O any, OT any](t *testing.T,
 }
 
 func TestUserAgentFilter(t *testing.T) {
-	testUserAgentFilter[httpOptions](t, HTTPEndpoint,
+	testUserAgentFilter[*httpOptions](t, HTTPEndpoint,
 		func(h *proto.HTTPEndpoint) *pb.MiddlewareConfiguration_UserAgentFilter {
 			return h.UserAgentFilter
 		})

--- a/config/webhook_verification_test.go
+++ b/config/webhook_verification_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestWebhookVerification(t *testing.T) {
-	cases := testCases[httpOptions, proto.HTTPEndpoint]{
+	cases := testCases[*httpOptions, proto.HTTPEndpoint]{
 		{
 			name: "absent",
 			opts: HTTPEndpoint(),

--- a/config/websocket_tcp_conversion_test.go
+++ b/config/websocket_tcp_conversion_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestWebsocketTCPConversion(t *testing.T) {
-	cases := testCases[httpOptions, proto.HTTPEndpoint]{
+	cases := testCases[*httpOptions, proto.HTTPEndpoint]{
 		{
 			name: "absent",
 			opts: HTTPEndpoint(),

--- a/session.go
+++ b/session.go
@@ -829,7 +829,7 @@ func (s *sessionImpl) ListenAndForward(ctx context.Context, url *url.URL, cfg co
 	}
 
 	// Set 'Forwards To'
-	tunnelCfg.WithForwardsTo(url.Host)
+	tunnelCfg.WithForwardsTo(url)
 
 	tun, err := s.Listen(ctx, cfg)
 	if err != nil {

--- a/tunnel_config.go
+++ b/tunnel_config.go
@@ -1,6 +1,10 @@
 package ngrok
 
-import "golang.ngrok.com/ngrok/internal/tunnel/proto"
+import (
+	"net/url"
+
+	"golang.ngrok.com/ngrok/internal/tunnel/proto"
+)
 
 // This is the internal-only interface that all config.Tunnel implementations
 // *also* implement. This lets us pull the necessary bits out of it without
@@ -13,5 +17,7 @@ type tunnelConfigPrivate interface {
 	Proto() string
 	Opts() any
 	Labels() map[string]string
-	WithForwardsTo(string)
+	// Extra config when auto-forwarding to a URL.
+	// Normal operation should use the functional builder.
+	WithForwardsTo(*url.URL)
 }


### PR DESCRIPTION
This also fixes a bug where the `forwards_to` field wasn't getting set because
we weren't using a pointer receiver to the `WithForwardsTo` builder hook.
