### PR TITLE
ngrok: add deprecated aliases for UserAgent filter options

### DIFF
--- a/config/user_agent_filter.go
+++ b/config/user_agent_filter.go
@@ -12,6 +12,20 @@ type userAgentFilter struct {
 	Deny []string
 }
 
+// WithAllowUserAgentFilter is a deprecated alias for [WithAllowUserAgent].
+//
+// Deprecated: use [WithAllowUserAgent] instead.
+func WithAllowUserAgentFilter(allow ...string) HTTPEndpointOption {
+	return WithAllowUserAgent(allow...)
+}
+
+// WithDenyUserAgentFilter is a deprecated alias for [WithDenyUserAgent].
+//
+// Deprecated: use [WithDenyUserAgent] instead.
+func WithDenyUserAgentFilter(allow ...string) HTTPEndpointOption {
+	return WithDenyUserAgent(allow...)
+}
+
 // WithAllowUserAgent adds user agent filtering to the endpoint.
 //
 // The allow argument is a regular expressions for the user-agent


### PR DESCRIPTION
This was a breaking change that snuck through.

Add some aliases that un-break it so that we're good semver citizens.
