### PR TITLE
ngrok: negotiate http/2 with tls backends if the http2 AppProtocol is requested

### DIFF
--- a/forward.go
+++ b/forward.go
@@ -126,6 +126,10 @@ func openBackend(ctx context.Context, logger log15.Logger, tun Tunnel, tunnelCon
 		}
 		logger.Debug("set default port", "port", port)
 	}
+	var appProto string
+	if fwdProto, ok := tun.(interface{ ForwardsProto() string }); ok {
+		appProto = fwdProto.ForwardsProto()
+	}
 
 	// Create TLS config if necessary
 	var tlsConfig *tls.Config
@@ -134,13 +138,11 @@ func openBackend(ctx context.Context, logger log15.Logger, tun Tunnel, tunnelCon
 			ServerName:    url.Hostname(),
 			Renegotiation: tls.RenegotiateOnceAsClient,
 		}
-		if fwdProto, ok := tun.(interface{ ForwardsProto() string }); ok {
-			// If the backend is TLS and we've requested HTTP2, we'll need to
-			// make the backend aware of that via ALPN.
-			if fwdProto.ForwardsProto() == "http2" {
-				tlsConfig.NextProtos = append(tlsConfig.NextProtos, "h2", "http/1.1")
-
-			}
+		// If the backend is TLS and we've requested HTTP2, we'll need to
+		// make the backend aware of that via ALPN.
+		if appProto == "http2" {
+			logger.Debug("negotiating http/2 via alpn")
+			tlsConfig.NextProtos = append(tlsConfig.NextProtos, "h2", "http/1.1")
 		}
 	}
 
@@ -152,7 +154,11 @@ func openBackend(ctx context.Context, logger log15.Logger, tun Tunnel, tunnelCon
 	if err != nil {
 		defer tunnelConn.Close()
 
-		if isHTTP(tunnelConn.Proto()) {
+		// TODO: this http error is only valid for http/1.1. If the edge is
+		//       expecting http/2, it'll end up being a proxy error instead.
+		//       We should probably find a better way to do this that doesn't involve
+		//       understanding http here.
+		if isHTTP(tunnelConn.Proto()) && appProto != "http2" {
 			_ = writeHTTPError(tunnelConn, err)
 		}
 		return nil, err

--- a/forward.go
+++ b/forward.go
@@ -134,6 +134,14 @@ func openBackend(ctx context.Context, logger log15.Logger, tun Tunnel, tunnelCon
 			ServerName:    url.Hostname(),
 			Renegotiation: tls.RenegotiateOnceAsClient,
 		}
+		if fwdProto, ok := tun.(interface{ ForwardsProto() string }); ok {
+			// If the backend is TLS and we've requested HTTP2, we'll need to
+			// make the backend aware of that via ALPN.
+			if fwdProto.ForwardsProto() == "http2" {
+				tlsConfig.NextProtos = append(tlsConfig.NextProtos, "h2", "http/1.1")
+
+			}
+		}
 	}
 
 	dialer := &net.Dialer{}

--- a/internal/tunnel/client/tunnel.go
+++ b/internal/tunnel/client/tunnel.go
@@ -16,6 +16,7 @@ type Tunnel interface {
 	RemoteBindConfig() *RemoteBindConfig
 	ID() string
 	ForwardsTo() string
+	ForwardsProto() string
 }
 
 type ProxyConn struct {

--- a/tunnel.go
+++ b/tunnel.go
@@ -191,6 +191,10 @@ func (t *tunnelImpl) Proto() string {
 	return t.Tunnel.RemoteBindConfig().ConfigProto
 }
 
+func (t *tunnelImpl) ForwardsProto() string {
+	return t.Tunnel.ForwardsProto()
+}
+
 func (t *tunnelImpl) ForwardsTo() string {
 	return t.Tunnel.ForwardsTo()
 }


### PR DESCRIPTION
Most https backends will only expect http/2 if it's in the ALPN extension to
the TLS handshake. Therefore, if we send them http/2 without making them aware
of it, bad things will happen.
