### PR TITLE
internal: fix a panic due to a racy Close routine

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,6 +1,7 @@
 if ! has nix_direnv_version || ! nix_direnv_version 2.2.0; then
   source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/2.2.0/direnvrc" "sha256-5EwyKnkJNQeXrRkYbwwRBcXbibosCJqyIUuz9Xq+LRc="
 fi
+dotenv_if_exists
 GOPATH=`pwd`/.direnv/go
 PATH=${GOPATH}/bin:${PATH}
 use flake

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -11,6 +11,7 @@ jobs:
       NGROK_TEST_ONLINE: 1
       NGROK_TEST_LONG: 1
       NGROK_TEST_FLAKEY: 1
+      NGROK_AUTHTOKEN: ${{ secrets.NGROK_AUTHTOKEN }}
     steps:
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v18

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.env
 .direnv
 *.swp
 cover.out

--- a/internal/tunnel/client/raw_session.go
+++ b/internal/tunnel/client/raw_session.go
@@ -46,11 +46,12 @@ type SessionHandler interface {
 // When RawSession.Accept() returns an error, that means the session is dead.
 // Client sessions run over a muxado session.
 type rawSession struct {
-	mux              *muxado.Heartbeat // the muxado session we're multiplexing streams over
-	id               string            // session id for logging purposes
-	handler          SessionHandler    // callbacks to allow the application to handle requests from the server
-	latency          chan time.Duration
-	closeLatencyOnce sync.Once
+	mux        *muxado.Heartbeat // the muxado session we're multiplexing streams over
+	id         string            // session id for logging purposes
+	handler    SessionHandler    // callbacks to allow the application to handle requests from the server
+	latency    chan time.Duration
+	closed     bool
+	closedLock sync.RWMutex
 	log.Logger
 }
 
@@ -230,10 +231,19 @@ func (s *rawSession) respFunc(raw net.Conn) func(v any) error {
 }
 
 func (s *rawSession) Close() error {
-	s.closeLatencyOnce.Do(func() {
+	// Close the muxado heartbeat session. After this, the goroutine calling the
+	// callback handler should exit.
+	err := s.mux.Close()
+
+	// Prevent sending on a closed channel in the callback handler by ensuring
+	// exclusive access to the channel and the closed boolean here.
+	s.closedLock.Lock()
+	defer s.closedLock.Unlock()
+	if !s.closed {
+		s.closed = true
 		close(s.latency)
-	})
-	return s.mux.Close()
+	}
+	return err
 }
 
 // This is essentially the RPC protocol. The request and response are just JSON
@@ -268,6 +278,15 @@ func (s *rawSession) rpc(reqtype proto.ReqType, req any, resp any) error {
 }
 
 func (s *rawSession) onHeartbeat(pingTime time.Duration, timeout bool) {
+	// make sure we don't send on a closed channel.
+	// Any number of `onHeartbeat` callbacks can be in flight at a given time,
+	// but only one Close.
+	s.closedLock.RLock()
+	defer s.closedLock.RUnlock()
+	if s.closed {
+		return
+	}
+
 	if timeout {
 		s.Error("heartbeat timeout, terminating session")
 		s.Close()

--- a/online_test.go
+++ b/online_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"io"
 	"math/rand"
@@ -43,16 +42,12 @@ func (tl *testLogger) Log(context context.Context, level log.LogLevel, msg strin
 		cpy[k] = v
 	}
 	cpy["test"] = tl.testName
-	bs, err := json.Marshal(cpy)
-	if err != nil {
-		bs = []byte("<marshal error>")
-	}
 	lvl, err := log.StringFromLogLevel(level)
 	if err != nil {
 		lvl = "UKWN"
 	}
 	lvl = strings.ToUpper(lvl)
-	tl.t.Logf("%s [%s] %s %s", time.Now().Format(time.RFC3339), lvl, msg, string(bs))
+	tl.t.Logf("%s [%s] %s %v", time.Now().Format(time.RFC3339), lvl, msg, cpy)
 }
 
 func expectChanError(t *testing.T, ch <-chan error, timeout time.Duration) {

--- a/tunnel.go
+++ b/tunnel.go
@@ -176,7 +176,8 @@ func (t *tunnelImpl) CloseWithContext(_ context.Context) error {
 			return err
 		}
 	}
-	return t.Tunnel.Close()
+	err := t.Tunnel.Close()
+	return err
 }
 
 func (t *tunnelImpl) Addr() net.Addr {


### PR DESCRIPTION
Resolves #150

This is a little awkward.

First off, we need to preserve the fact that the latency channel gets closed.
Downstream code relies on this property.

The big problem is that the process sending things on the latency channel is
completely out-of-band with regard to the Close method. Ideally, the Heartbeat
type would also take a "cleanup" closure that would only be called after all of
its goroutines have exited, but that's a muxado change that I don't really want
to make right now.

Instead, we just have to make `Close` and `onHeartbeat` race-free.

