### PR TITLE
ngrok: fix tests after anonymous deprecation

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,6 +1,7 @@
 if ! has nix_direnv_version || ! nix_direnv_version 2.2.0; then
   source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/2.2.0/direnvrc" "sha256-5EwyKnkJNQeXrRkYbwwRBcXbibosCJqyIUuz9Xq+LRc="
 fi
+dotenv_if_exists
 GOPATH=`pwd`/.direnv/go
 PATH=${GOPATH}/bin:${PATH}
 use flake

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -11,6 +11,7 @@ jobs:
       NGROK_TEST_ONLINE: 1
       NGROK_TEST_LONG: 1
       NGROK_TEST_FLAKEY: 1
+      NGROK_AUTHTOKEN: ${{ secrets.NGROK_AUTHTOKEN }}
     steps:
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v18

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.env
 .direnv
 *.swp
 cover.out

--- a/online_test.go
+++ b/online_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"io"
 	"math/rand"
@@ -43,16 +42,12 @@ func (tl *testLogger) Log(context context.Context, level log.LogLevel, msg strin
 		cpy[k] = v
 	}
 	cpy["test"] = tl.testName
-	bs, err := json.Marshal(cpy)
-	if err != nil {
-		bs = []byte("<marshal error>")
-	}
 	lvl, err := log.StringFromLogLevel(level)
 	if err != nil {
 		lvl = "UKWN"
 	}
 	lvl = strings.ToUpper(lvl)
-	tl.t.Logf("%s [%s] %s %s", time.Now().Format(time.RFC3339), lvl, msg, string(bs))
+	tl.t.Logf("%s [%s] %s %v", time.Now().Format(time.RFC3339), lvl, msg, cpy)
 }
 
 func expectChanError(t *testing.T, ch <-chan error, timeout time.Duration) {


### PR DESCRIPTION
Some tests worked with unauthenticated sessions, which no longer work at all.

Make sure they're either authenticated or gone.

Also some miscellaneous testing improvements, such as dotenv support, better
logging, and better timeouts on the `exited` channel.
