### PR TITLE
multiple session legs support

### DIFF
--- a/internal/tunnel/client/reconnecting.go
+++ b/internal/tunnel/client/reconnecting.go
@@ -382,7 +382,9 @@ func (s *reconnectingSession) connect(acceptErr error, connSession *session) err
 		// check if more sessions need to be established
 		sendStateChange := true
 		if desiredLegs > len(s.sessions) {
-			// set up the next connection
+			// set up the next connection. additional sessions will
+			// continue to chain on from there until all legs are
+			// established
 			s.createTunnelClientSession(s)
 			// not done with initial setup yet
 			sendStateChange = false

--- a/internal/tunnel/client/reconnecting.go
+++ b/internal/tunnel/client/reconnecting.go
@@ -99,14 +99,14 @@ type reconnectingSession struct {
 	stateChanges chan<- error
 	clientID     string
 	cb           ReconnectCallback
-	swapper      *swapRaw
-	*session
+	sessions     []*session
+	log.Logger
 }
 
-type RawSessionDialer func() (RawSession, error)
-type ReconnectCallback func(s Session) error
+type RawSessionDialer func(legNumber uint32) (RawSession, error)
+type ReconnectCallback func(s Session, r RawSession, legNumber uint32) (int, error)
 
-// Establish a Session that reconnects across temporary network failures. The
+// Establish Session(s) that reconnect across temporary network failures. The
 // returned Session object uses the given dialer to reconnect whenever Accept
 // would have failed with a temporary error. When a reconnecting session is
 // re-established, it reissues the Auth call and Listen calls for each tunnel
@@ -122,59 +122,162 @@ type ReconnectCallback func(s Session) error
 //
 // If the stateChanges channel is not serviced by the caller, the
 // ReconnectingSession will hang.
+//
+// When using MultiLeg, there will be multiple underlying Sessions which are kept
+// in sync. This struct will broadcast calls to all underlying Sessions.
 func NewReconnectingSession(logger log.Logger, dialer RawSessionDialer, stateChanges chan<- error, cb ReconnectCallback) Session {
-	swapper := new(swapRaw)
 	s := &reconnectingSession{
 		dialer:       dialer,
 		stateChanges: stateChanges,
 		cb:           cb,
-		swapper:      swapper,
-		session: &session{
-			tunnels: make(map[string]*tunnel),
-			raw:     swapper,
-			Logger:  newLogger(logger),
-		},
+		Logger:       logger,
 	}
 
 	// setup an initial connection
-	go func() {
-		err := s.connect(nil)
-		if err != nil {
-			return
-		}
-		s.receive()
-	}()
+	s.createTunnelClientSession(logger)
 
 	return s
 }
 
-func (s *reconnectingSession) Close() error {
-	atomic.StoreInt32(&s.closed, 1)
-	return s.session.Close()
+func (s *reconnectingSession) createTunnelClientSession(logger log.Logger) {
+	swapper := new(swapRaw)
+	tcs := &session{
+		swapper:   swapper,
+		raw:       swapper,
+		Logger:    newLogger(logger),
+		legNumber: uint32(len(s.sessions)),
+	}
+	s.sessions = append(s.sessions, tcs)
+
+	go func() {
+		err := s.connect(nil, tcs)
+		if err != nil {
+			return
+		}
+		s.receive(tcs)
+	}()
 }
 
-func (s *reconnectingSession) receive() {
+func (s *reconnectingSession) firstSession() *session {
+	if len(s.sessions) == 0 {
+		return nil
+	}
+	return s.sessions[0]
+}
+
+func (s *reconnectingSession) Heartbeat() (time.Duration, error) {
+	if sess := s.firstSession(); sess != nil {
+		return sess.Heartbeat()
+	}
+	return 0, ErrSessionNotReady
+}
+
+func (s *reconnectingSession) Latency() <-chan time.Duration {
+	if sess := s.firstSession(); sess != nil {
+		return sess.Latency()
+	}
+	return nil
+}
+
+func (s *reconnectingSession) Listen(protocol string, opts any, extra proto.BindExtra, forwardsTo string, forwardsProto string) (Tunnel, error) {
+	return s.listenTunnel(func(session *session) (Tunnel, error) {
+		return session.Listen(protocol, opts, extra, forwardsTo, forwardsProto)
+	})
+}
+
+func (s *reconnectingSession) ListenLabel(labels map[string]string, metadata string, forwardsTo string, forwardsProto string) (Tunnel, error) {
+	return s.listenTunnel(func(session *session) (Tunnel, error) {
+		return session.ListenLabel(labels, metadata, forwardsTo, forwardsProto)
+	})
+}
+
+func (s *reconnectingSession) listenTunnel(listen func(*session) (Tunnel, error)) (Tunnel, error) {
+	if sess := s.firstSession(); sess != nil {
+		tun, err := listen(sess)
+		if err != nil {
+			return nil, err
+		}
+		// connect this tunnel to the other legs
+		for _, session := range s.sessions[1:] {
+			if e := reconnectTunnelToSession(session.raw, tun.(*tunnel), make(map[string]*tunnel), tun.ID()); e != nil {
+				return nil, e
+			}
+			// use locking method
+			session.addTunnel(tun.ID(), tun.(*tunnel))
+		}
+		return tun, nil
+	}
+	return nil, ErrSessionNotReady
+}
+
+func (s *reconnectingSession) SrvInfo() (resp proto.SrvInfoResp, err error) {
+	if sess := s.firstSession(); sess != nil {
+		return sess.SrvInfo()
+	}
+	return proto.SrvInfoResp{}, ErrSessionNotReady
+}
+
+func (s *reconnectingSession) ListenHTTP(opts *proto.HTTPEndpoint, extra proto.BindExtra, forwardsTo string, forwardsProto string) (Tunnel, error) {
+	return s.Listen("http", opts, extra, forwardsTo, forwardsProto)
+}
+
+func (s *reconnectingSession) ListenHTTPS(opts *proto.HTTPEndpoint, extra proto.BindExtra, forwardsTo string, forwardsProto string) (Tunnel, error) {
+	return s.Listen("https", opts, extra, forwardsTo, forwardsProto)
+}
+
+func (s *reconnectingSession) ListenTCP(opts *proto.TCPEndpoint, extra proto.BindExtra, forwardsTo string) (Tunnel, error) {
+	return s.Listen("tcp", opts, extra, forwardsTo, "")
+}
+
+func (s *reconnectingSession) ListenTLS(opts *proto.TLSEndpoint, extra proto.BindExtra, forwardsTo string) (Tunnel, error) {
+	return s.Listen("tls", opts, extra, forwardsTo, "")
+}
+
+func (s *reconnectingSession) Close() error {
+	atomic.StoreInt32(&s.closed, 1)
+	var err error
+	for _, session := range s.sessions {
+		serr := session.Close()
+		if serr != nil {
+			err = serr
+		}
+	}
+	return err
+}
+
+func (s *reconnectingSession) CloseTunnel(clientID string, e error) error {
+	var err error
+	for _, session := range s.sessions {
+		serr := session.CloseTunnel(clientID, e)
+		if serr != nil {
+			err = serr
+		}
+	}
+	return err
+}
+
+func (s *reconnectingSession) receive(session *session) {
 	// when we shut down, close all of the open tunnels
 	defer func() {
-		s.RLock()
-		for _, t := range s.tunnels {
+		session.RLock()
+		for _, t := range session.tunnels {
 			go t.Close()
 		}
-		s.RUnlock()
+		session.RUnlock()
 	}()
 
 	for {
 		// accept the next proxy connection
-		proxy, err := s.raw.Accept()
+		proxy, err := session.raw.Accept()
 		if err == nil {
-			go s.handleProxy(proxy)
+			go session.handleProxy(proxy)
 			continue
 		}
 
 		// we disconnected, reconnect
-		err = s.connect(err)
+		err = s.connect(err, session)
 		if err != nil {
-			s.Info("accept failed", "err", err)
+			session.Info("accept failed", "err", err)
 			// permanent failure
 			return
 		}
@@ -182,7 +285,11 @@ func (s *reconnectingSession) receive() {
 }
 
 func (s *reconnectingSession) Auth(extra proto.AuthExtra) (resp proto.AuthResp, err error) {
-	resp, err = s.raw.Auth(s.clientID, extra)
+	if len(s.sessions) < int(extra.LegNumber) {
+		err = errors.New("leg number out of range")
+		return
+	}
+	resp, err = s.sessions[extra.LegNumber].raw.Auth(s.clientID, extra)
 	if err != nil {
 		return
 	}
@@ -194,7 +301,7 @@ func (s *reconnectingSession) Auth(extra proto.AuthExtra) (resp proto.AuthResp, 
 	return
 }
 
-func (s *reconnectingSession) connect(acceptErr error) error {
+func (s *reconnectingSession) connect(acceptErr error, connSession *session) error {
 	boff := &backoff.Backoff{
 		Min:    500 * time.Millisecond,
 		Max:    30 * time.Second,
@@ -223,53 +330,25 @@ func (s *reconnectingSession) connect(acceptErr error) error {
 		return err
 	}
 
-	restartBinds := func(raw RawSession) (err error) {
-		s.Lock()
-		defer s.Unlock()
+	restartBinds := func(session *session) (err error) {
+		session.Lock()
+		defer session.Unlock()
+		raw := session.raw
 
 		// reconnected tunnels, which may have different IDs
-		newTunnels := make(map[string]*tunnel, len(s.tunnels))
-		for oldID, t := range s.tunnels {
-			// set the returned token for reconnection
-			tCfg := t.RemoteBindConfig()
-			t.bindExtra.Token = tCfg.Token
-
-			var respErr string
-			if tCfg.Labels != nil {
-				resp, err := raw.ListenLabel(tCfg.Labels, tCfg.Metadata, t.ForwardsTo(), t.ForwardsProto())
-				if err != nil {
-					return err
-				}
-				respErr = resp.Error
-				if resp.ID != "" {
-					t.id.Store(resp.ID)
-					newTunnels[resp.ID] = t
-				} else {
-					// Otherwise save the old tunnel I guess? Maybe next reconnect gets it?
-					// This doesn't seem quite right though...
-					newTunnels[oldID] = t
-				}
-			} else {
-				resp, err := raw.Listen(tCfg.ConfigProto, tCfg.Opts, t.bindExtra, t.ID(), t.ForwardsTo(), t.ForwardsProto())
-				if err != nil {
-					return err
-				}
-				respErr = resp.Error
-				// same ID, no need to change
-				newTunnels[oldID] = t
-			}
-
-			if respErr != "" {
-				return errors.New(respErr)
+		newTunnels := make(map[string]*tunnel, len(session.tunnels))
+		for oldID, t := range session.tunnels {
+			if err := reconnectTunnelToSession(raw, t, newTunnels, oldID); err != nil {
+				return err
 			}
 		}
-		s.tunnels = newTunnels
+		session.tunnels = newTunnels
 		return nil
 	}
 
 	if acceptErr != nil {
 		if atomic.LoadInt32(&s.closed) == 0 {
-			s.Error("session closed, starting reconnect loop", "err", acceptErr)
+			connSession.Error("session closed, starting reconnect loop", "err", acceptErr)
 			s.stateChanges <- acceptErr
 		}
 	}
@@ -284,33 +363,79 @@ func (s *reconnectingSession) connect(acceptErr error) error {
 		}
 
 		// dial the tunnel server
-		raw, err := s.dialer()
+		raw, err := s.dialer(connSession.legNumber)
 		if err != nil {
 			failTemp(err, raw)
 			continue
 		}
 
 		// successfully reconnected
-		s.swapper.set(raw)
+		connSession.swapper.set(raw)
 
 		// callback for authentication
-		if err := s.cb(s); err != nil {
-			failTemp(err, raw)
-			continue
-		}
-
-		// re-establish binds
-		err = restartBinds(raw)
+		desiredLegs, err := s.cb(s, raw, connSession.legNumber)
 		if err != nil {
 			failTemp(err, raw)
 			continue
 		}
 
-		// reset wait
-		boff.Reset()
+		// check if more sessions need to be established
+		sendStateChange := true
+		if desiredLegs > len(s.sessions) {
+			// set up the next connection
+			s.createTunnelClientSession(s)
+			// not done with initial setup yet
+			sendStateChange = false
+		}
 
-		s.Info("client session established")
-		s.stateChanges <- nil
+		// re-establish binds
+		err = restartBinds(connSession)
+		if err != nil {
+			failTemp(err, raw)
+			continue
+		}
+
+		if sendStateChange {
+			// reset wait
+			boff.Reset()
+
+			s.Info("client session established")
+			s.stateChanges <- nil
+		}
 		return nil
 	}
+}
+
+func reconnectTunnelToSession(raw RawSession, t *tunnel, newTunnels map[string]*tunnel, oldID string) error {
+	// set the returned token for reconnection
+	tCfg := t.RemoteBindConfig()
+	t.bindExtra.Token = tCfg.Token
+
+	var respErr string
+	if tCfg.Labels != nil {
+		resp, err := raw.ListenLabel(tCfg.Labels, tCfg.Metadata, t.ForwardsTo(), t.ForwardsProto())
+		if err != nil {
+			return err
+		}
+		respErr = resp.Error
+		if resp.ID != "" {
+			t.id.Store(resp.ID)
+			newTunnels[resp.ID] = t
+		} else {
+			newTunnels[oldID] = t
+		}
+	} else {
+		resp, err := raw.Listen(tCfg.ConfigProto, tCfg.Opts, t.bindExtra, t.ID(), t.ForwardsTo(), t.ForwardsProto())
+		if err != nil {
+			return err
+		}
+		respErr = resp.Error
+
+		newTunnels[oldID] = t
+	}
+
+	if respErr != "" {
+		return errors.New(respErr)
+	}
+	return nil
 }

--- a/internal/tunnel/client/reconnecting.go
+++ b/internal/tunnel/client/reconnecting.go
@@ -199,7 +199,7 @@ func (s *reconnectingSession) listenTunnel(listen func(*session) (Tunnel, error)
 		}
 		// connect this tunnel to the other legs
 		for _, session := range s.sessions[1:] {
-			if e := reconnectTunnelToSession(session.raw, tun.(*tunnel), make(map[string]*tunnel), tun.ID()); e != nil {
+			if e := s.reconnectTunnelToSession(session.raw, tun.(*tunnel), make(map[string]*tunnel), tun.ID()); e != nil {
 				return nil, e
 			}
 			// use locking method
@@ -338,7 +338,7 @@ func (s *reconnectingSession) connect(acceptErr error, connSession *session) err
 		// reconnected tunnels, which may have different IDs
 		newTunnels := make(map[string]*tunnel, len(session.tunnels))
 		for oldID, t := range session.tunnels {
-			if err := reconnectTunnelToSession(raw, t, newTunnels, oldID); err != nil {
+			if err := s.reconnectTunnelToSession(raw, t, newTunnels, oldID); err != nil {
 				return err
 			}
 		}
@@ -406,7 +406,7 @@ func (s *reconnectingSession) connect(acceptErr error, connSession *session) err
 	}
 }
 
-func reconnectTunnelToSession(raw RawSession, t *tunnel, newTunnels map[string]*tunnel, oldID string) error {
+func (s *reconnectingSession) reconnectTunnelToSession(raw RawSession, t *tunnel, newTunnels map[string]*tunnel, oldID string) error {
 	// set the returned token for reconnection
 	tCfg := t.RemoteBindConfig()
 	t.bindExtra.Token = tCfg.Token

--- a/internal/tunnel/client/session.go
+++ b/internal/tunnel/client/session.go
@@ -76,10 +76,12 @@ type Session interface {
 }
 
 type session struct {
-	raw RawSession
+	swapper *swapRaw
+	raw     RawSession
 	sync.RWMutex
 	log.Logger
-	tunnels map[string]*tunnel
+	tunnels   map[string]*tunnel
+	legNumber uint32
 }
 
 // NewSession starts a new go-tunnel client session running over the given

--- a/internal/tunnel/proto/msg.go
+++ b/internal/tunnel/proto/msg.go
@@ -135,6 +135,11 @@ type AuthExtra struct {
 	CustomCAs       bool
 
 	ClientType ClientType // The type of client this is. Currently agent and library clients are supported
+
+	// The leg number of the client connection associated with this session.
+	// Defaults to zero, will be 1 or more for the additional connected
+	// leg(s) when multi-leg is engaged.
+	LegNumber uint32
 }
 
 type ClientType string
@@ -184,6 +189,11 @@ func (avd *AgentVersionDeprecated) Error() string {
 	return "Your agent is deprecated. Please update " + to + when
 }
 
+type ConnectAddress struct {
+	Region     string
+	ServerAddr string
+}
+
 type AuthRespExtra struct {
 	Version string // server version
 	Region  string // server region
@@ -195,6 +205,7 @@ type AuthRespExtra struct {
 	PlanName           string
 	Banner             string
 	DeprecationWarning *AgentVersionDeprecated
+	ConnectAddresses   []ConnectAddress
 }
 
 // A client sends this message to the server over a new stream

--- a/session.go
+++ b/session.go
@@ -977,7 +977,7 @@ func (s *sessionImpl) Heartbeat() (time.Duration, error) {
 func (s *sessionImpl) Latency() <-chan time.Duration {
 	return s.inner().Latency()
 }
-func (s *sessionImpl) ConnectAddreses() []ConnectAddress {
+func (s *sessionImpl) ConnectAddresses() []ConnectAddress {
 	connectAddresses := make([]ConnectAddress, len(s.inner().ConnectAddresses))
 	for i, addr := range s.inner().ConnectAddresses {
 		connectAddresses[i] = ConnectAddress(addr)

--- a/session.go
+++ b/session.go
@@ -43,6 +43,9 @@ func (avd *AgentVersionDeprecated) Error() string {
 	return (*proto.AgentVersionDeprecated)(avd).Error()
 }
 
+// ConnectAddress is a type wrapper for [proto.ConnectAddress]
+type ConnectAddress proto.ConnectAddress
+
 // Session encapsulates an established session with the ngrok service. Sessions
 // recover from network failures by automatically reconnecting.
 type Session interface {
@@ -143,6 +146,10 @@ type connectConfig struct {
 	// The address of the ngrok server to connect to.
 	// Defaults to `connect.ngrok-agent.com:443`
 	ServerAddr string
+	// The optional addresses of the additional ngrok servers to connect to.
+	AdditionalServerAddrs []string
+	// Enable using multiple session legs
+	EnableMultiLeg bool
 	// The [tls.Config] used when connecting to the ngrok server
 	TLSConfigCustomizer func(*tls.Config)
 	// The [x509.CertPool] used to authenticate the ngrok server certificate.
@@ -284,6 +291,28 @@ func WithRegion(region string) ConnectOption {
 func WithServer(addr string) ConnectOption {
 	return func(cfg *connectConfig) {
 		cfg.ServerAddr = addr
+	}
+}
+
+// WithAdditionalServers configures the network address to dial to connect to the ngrok
+// service on secondary legs. Use this option only if you are connecting to a custom agent
+// ingress, and have enabled multi leg.
+//
+// See the [server_addr parameter in the ngrok docs] for additional details.
+//
+// [server_addr parameter in the ngrok docs]: https://ngrok.com/docs/ngrok-agent/config#server_addr
+func WithAdditionalServers(addrs []string) ConnectOption {
+	return func(cfg *connectConfig) {
+		cfg.AdditionalServerAddrs = addrs
+	}
+}
+
+// WithMultiLeg as true allows connecting to the ngrok service on secondary legs.
+//
+// See [WithAdditionalServers] if connecting to a custom agent ingress.
+func WithMultiLeg(enable bool) ConnectOption {
+	return func(cfg *connectConfig) {
+		cfg.EnableMultiLeg = enable
 	}
 }
 
@@ -508,15 +537,6 @@ func Connect(ctx context.Context, opts ...ConnectOption) (Session, error) {
 		cfg.ServerAddr = defaultServer
 	}
 
-	tlsConfig := &tls.Config{
-		RootCAs:    cfg.CAPool,
-		ServerName: strings.Split(cfg.ServerAddr, ":")[0],
-		MinVersion: tls.VersionTLS12,
-	}
-	if cfg.TLSConfigCustomizer != nil {
-		cfg.TLSConfigCustomizer(tlsConfig)
-	}
-
 	var dialer Dialer
 
 	if cfg.Dialer != nil {
@@ -555,10 +575,23 @@ func Connect(ctx context.Context, opts ...ConnectOption) (Session, error) {
 		updateHandler:  cfg.UpdateHandler,
 	}
 
-	rawDialer := func() (tunnel_client.RawSession, error) {
-		conn, err := dialer.DialContext(ctx, "tcp", cfg.ServerAddr)
+	rawDialer := func(legNumber uint32) (tunnel_client.RawSession, error) {
+		serverAddr := cfg.ServerAddr
+		if legNumber > 0 && len(cfg.AdditionalServerAddrs) >= int(legNumber) {
+			serverAddr = cfg.AdditionalServerAddrs[legNumber-1]
+		}
+		tlsConfig := &tls.Config{
+			RootCAs:    cfg.CAPool,
+			ServerName: strings.Split(serverAddr, ":")[0],
+			MinVersion: tls.VersionTLS12,
+		}
+		if cfg.TLSConfigCustomizer != nil {
+			cfg.TLSConfigCustomizer(tlsConfig)
+		}
+
+		conn, err := dialer.DialContext(ctx, "tcp", serverAddr)
 		if err != nil {
-			return nil, errSessionDial{cfg.ServerAddr, err}
+			return nil, errSessionDial{serverAddr, err}
 		}
 
 		conn = tls.Client(conn, tlsConfig)
@@ -613,14 +646,15 @@ func Connect(ctx context.Context, opts ...ConnectOption) (Session, error) {
 		UpdateUnsupportedError:  cfg.remoteUpdateErr,
 	}
 
-	reconnect := func(sess tunnel_client.Session) error {
+	reconnect := func(sess tunnel_client.Session, raw tunnel_client.RawSession, legNumber uint32) (int, error) {
+		auth.LegNumber = legNumber
 		resp, err := sess.Auth(auth)
 		if err != nil {
 			remote := false
 			if resp.Error != "" {
 				remote = true
 			}
-			return errAuthFailed{remote, err}
+			return 0, errAuthFailed{remote, err}
 		}
 
 		if resp.Extra.DeprecationWarning != nil {
@@ -638,7 +672,7 @@ func Connect(ctx context.Context, opts ...ConnectOption) (Session, error) {
 			logger.Warn(warning.Error(), vars...)
 		}
 
-		session.setInner(&sessionInner{
+		sessionInner := &sessionInner{
 			Session:            sess,
 			Region:             resp.Extra.Region,
 			ProtoVersion:       resp.Version,
@@ -649,12 +683,21 @@ func Connect(ctx context.Context, opts ...ConnectOption) (Session, error) {
 			Banner:             resp.Extra.Banner,
 			SessionDuration:    resp.Extra.SessionDuration,
 			DeprecationWarning: resp.Extra.DeprecationWarning,
+			ConnectAddresses:   resp.Extra.ConnectAddresses,
 			Logger:             logger,
-		})
+		}
+
+		if legNumber == 0 {
+			session.setInner(sessionInner)
+		}
 
 		if cfg.HeartbeatHandler != nil {
+			// plumb a session with the proper region to the heartbeatHandler
+			heartbeatSession := new(sessionImpl)
+			heartbeatSession.setInner(sessionInner)
 			go func() {
-				beats := session.Latency()
+				// use the raw latency channel in case this is a multi-leg session
+				beats := raw.Latency()
 				for {
 					select {
 					case <-ctx.Done():
@@ -663,14 +706,39 @@ func Connect(ctx context.Context, opts ...ConnectOption) (Session, error) {
 						if !ok {
 							return
 						}
-						cfg.HeartbeatHandler(ctx, session, latency)
+						cfg.HeartbeatHandler(ctx, heartbeatSession, latency)
 					}
 				}
 			}()
 		}
 
 		auth.Cookie = resp.Extra.Cookie
-		return nil
+
+		// store any connect server addresses for use in subsequent legs
+		if cfg.EnableMultiLeg && legNumber == 0 && len(resp.Extra.ConnectAddresses) > 1 {
+			testServerAddr := strings.Replace(cfg.ServerAddr, ".lan", "", 1)
+			testServerAddr = strings.Replace(testServerAddr, ".dev-", ".", 1)
+			testServerAddr = strings.Replace(testServerAddr, ".stage-", ".", 1)
+			overrideAdditionalServers := len(cfg.AdditionalServerAddrs) == 0
+			for i, ca := range resp.Extra.ConnectAddresses {
+				if i == 0 {
+					if testServerAddr == defaultServer {
+						// lock in the leg 0 region
+						logger.Debug("first leg using region", "region", resp.Extra.Region, "server", ca.ServerAddr)
+						cfg.ServerAddr = ca.ServerAddr
+					}
+				} else if overrideAdditionalServers {
+					cfg.AdditionalServerAddrs = append(cfg.AdditionalServerAddrs, ca.ServerAddr)
+				}
+			}
+		}
+
+		// if we are using multi-leg, we need to know how many legs to connect
+		desiredLegs := 1
+		if cfg.EnableMultiLeg {
+			desiredLegs = 1 + len(cfg.AdditionalServerAddrs)
+		}
+		return desiredLegs, nil
 	}
 
 	sess := tunnel_client.NewReconnectingSession(logger, rawDialer, stateChanges, reconnect)
@@ -755,6 +823,7 @@ type sessionInner struct {
 	Banner             string
 	SessionDuration    int64
 	DeprecationWarning *proto.AgentVersionDeprecated
+	ConnectAddresses   []proto.ConnectAddress
 
 	Logger log15.Logger
 }
@@ -908,6 +977,13 @@ func (s *sessionImpl) Heartbeat() (time.Duration, error) {
 }
 func (s *sessionImpl) Latency() <-chan time.Duration {
 	return s.inner().Latency()
+}
+func (s *sessionImpl) ConnectAddreses() []ConnectAddress {
+	connectAddresses := make([]ConnectAddress, len(s.inner().ConnectAddresses))
+	for i, addr := range s.inner().ConnectAddresses {
+		connectAddresses[i] = ConnectAddress(addr)
+	}
+	return connectAddresses
 }
 
 type remoteCallbackHandler struct {

--- a/session.go
+++ b/session.go
@@ -43,9 +43,6 @@ func (avd *AgentVersionDeprecated) Error() string {
 	return (*proto.AgentVersionDeprecated)(avd).Error()
 }
 
-// ConnectAddress is a type wrapper for [proto.ConnectAddress]
-type ConnectAddress proto.ConnectAddress
-
 // Session encapsulates an established session with the ngrok service. Sessions
 // recover from network failures by automatically reconnecting.
 type Session interface {
@@ -977,10 +974,10 @@ func (s *sessionImpl) Heartbeat() (time.Duration, error) {
 func (s *sessionImpl) Latency() <-chan time.Duration {
 	return s.inner().Latency()
 }
-func (s *sessionImpl) ConnectAddresses() []ConnectAddress {
-	connectAddresses := make([]ConnectAddress, len(s.inner().ConnectAddresses))
+func (s *sessionImpl) ConnectAddresses() []struct{ Region, ServerAddr string } {
+	connectAddresses := make([]struct{ Region, ServerAddr string }, len(s.inner().ConnectAddresses))
 	for i, addr := range s.inner().ConnectAddresses {
-		connectAddresses[i] = ConnectAddress(addr)
+		connectAddresses[i] = struct{ Region, ServerAddr string }{addr.Region, addr.ServerAddr}
 	}
 	return connectAddresses
 }


### PR DESCRIPTION
Adding support for multiple session legs.

This adds two configuration options:

- `WithAdditionalServers(addrs []string)`
- `WithMultiLeg(enable bool)`

If multi-leg is enabled, then the `ConnectAddresses` in the Auth response of the first session are used to determine what additional sessions should be set up. The `ReconnectingSession` will accumulate more sessions on connect, then return as normal. `ReconnectionSession` will handle fan-out of calls to the underlying `tunnel_client.Session` as before, except now there are multiple of them.

If the first connection is made using least-latency, it will lock in to that `ConnectAddress` so reconnects will go back to the same region. Heartbeat callbacks are done for each underlying session, including appropriate region and latency information.