### PR TITLE
feat(ci): Add check for go mod tidy

### DIFF
--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -13,11 +13,17 @@ jobs:
       NGROK_TEST_FLAKEY: 1
       NGROK_AUTHTOKEN: ${{ secrets.NGROK_AUTHTOKEN }}
     steps:
-    - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v18
+    - uses: actions/checkout@v4
+    - uses: cachix/install-nix-action@v27
     - uses: HatsuneMiku3939/direnv-action@v1
     - name: direnv allow
       run: direnv allow .
+    - name: go mod tidy
+      run: direnv exec . go mod tidy
+    - name: exit if not tidy
+      run: |
+        git diff --exit-code go.mod
+        git diff --exit-code go.sum
     - name: Build
       run: direnv exec . go build -v ./...
     - name: Build Examples

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	golang.org/x/sync v0.3.0
 	google.golang.org/protobuf v1.31.0
 	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -23,5 +24,4 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/sys v0.12.0 // indirect
 	golang.org/x/term v0.12.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
Supersedes #182 

Adds a check to make sure that go mod tidy produces no diff for the go.mod or go.sum files.

Also updates some of our actions versions while we are here.