### PR TITLE
alias `WithTrafficPolicy` to `WithPolicyString`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.11.0
+
+Changes:
+
+- Adds `WithTrafficPolicy` function, replacing `WithPolicyString`
+
 ## 1.10.0
 
 Enhancements:

--- a/config/policy.go
+++ b/config/policy.go
@@ -15,10 +15,10 @@ type rule po.Rule
 type action po.Action
 type trafficPolicy string
 
-// WithPolicyString configures this edge with the provided policy configuration
-// passed as a json or yaml string and overwrites any previously-set traffic policy
+// WithTrafficPolicy configures this edge with the provided policy configuration
+// passed as a json or yaml string and overwrites any previously-set traffic policy.
 // https://ngrok.com/docs/http/traffic-policy
-func WithPolicyString(str string) interface {
+func WithTrafficPolicy(str string) interface {
 	HTTPEndpointOption
 	TLSEndpointOption
 	TCPEndpointOption
@@ -27,6 +27,16 @@ func WithPolicyString(str string) interface {
 		panic(errors.New("provided string is neither valid JSON nor valid YAML"))
 	}
 	return trafficPolicy(str)
+}
+
+// WithPolicyString is deprecated, use WithTrafficPolicy instead.
+// https://ngrok.com/docs/http/traffic-policy/
+func WithPolicyString(str string) interface {
+	HTTPEndpointOption
+	TLSEndpointOption
+	TCPEndpointOption
+} {
+	return WithTrafficPolicy(str)
 }
 
 func (p trafficPolicy) ApplyTLS(opts *tlsOptions) {
@@ -51,7 +61,7 @@ func isYamlStr(yamlStr string) bool {
 	return yaml.Unmarshal([]byte(yamlStr), &yml) == nil
 }
 
-// WithPolicy is deprecated, use WithPolicyString instead.
+// WithPolicy is deprecated, use WithTrafficPolicy instead.
 // https://ngrok.com/docs/http/traffic-policy/
 func WithPolicy(p po.Policy) interface {
 	HTTPEndpointOption

--- a/config/policy_test.go
+++ b/config/policy_test.go
@@ -89,7 +89,7 @@ inbound:
 		{
 			name: "with valid JSON policy string",
 			opts: optsFunc(
-				WithPolicyString(`
+				WithTrafficPolicy(`
 					{
 						"inbound":[
 							{
@@ -145,7 +145,7 @@ inbound:
 		{
 			name: "with valid YAML policy string",
 			opts: optsFunc(
-				WithPolicyString(yamlPolicy)),
+				WithTrafficPolicy(yamlPolicy)),
 			expectOpts: func(t *testing.T, opts *O) {
 				actual := getPolicies(opts)
 				require.NotEmpty(t, actual)


### PR DESCRIPTION
This change adds a `WithTrafficPolicy` function for configuring traffic policy on a tunnel. This has the exact same behavior as `WithPolicyString` and solely exists to bring naming in line with the rest of the product. 

`WithPolicyString` now just calls `WithTrafficPolicy`. 

`WithPolicyString` doc string has been updated to include a deprecation warning.