### PR TITLE
feat: Increase logging around proxy conn

### DIFF
--- a/internal/tunnel/client/session.go
+++ b/internal/tunnel/client/session.go
@@ -238,8 +238,19 @@ func (s *session) handleProxy(proxy netx.LoggedConn) {
 
 	tunnel.shut.RLock()
 	defer tunnel.shut.RUnlock()
+
+	// Wrap the proxy conn so it has a proper RemoteAddr()
+	pconn := newProxyConn(proxy, proxyHdr)
+	s.Logger.Debug("handling connection",
+		"id", proxyHdr.ID,
+		"client.addr", pconn.Conn.RemoteAddr(),
+		"proxy.proto", proxyHdr.Proto,
+		"proxy.remote_addr", proxy.RemoteAddr(),
+		"proxy.local_addr", proxy.LocalAddr(),
+	)
+
 	// deliver proxy connection + wrap it so it has a proper RemoteAddr()
-	tunnel.handleConn(newProxyConn(proxy, proxyHdr))
+	tunnel.handleConn(pconn)
 }
 
 // Public so we can use it in lib/tunnel/server/functional_test.go


### PR DESCRIPTION
## What

I was looking specifically for the `client.addr` and didn't see it being logged anywhere. We were previously logging this in the ngrok-operator project when we were handling dialing the upstream and joining connections on our own. Now that we are using an endpoint forwarder to clean up code in the ngrok-operator, we no longer see these logs messages when increasing log verbosity.

## How
Inside `handleProxy` seemed like the most reasonable place to log this. It still feels like there might be a little bit of overlap with https://github.com/ngrok/ngrok-go/blob/15e612c3535344f175a06bc3d286cb6977ff2768/internal/tunnel/client/raw_session.go#L167. However, we don't have the `client.addr` there, so we can't add it there.



I'm hoping this will be generally useful, but if we don't think it will be, we can close this.

