### PR TITLE
Convert interfaces into concrete structs

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -17,27 +17,6 @@ import (
 	"golang.ngrok.com/ngrok/v2/rpc"
 )
 
-// Agent is the main interface for interacting with the ngrok service.
-type Agent interface {
-	// Connect begins a new Session by connecting and authenticating to the ngrok cloud service.
-	Connect(context.Context) error
-
-	// Disconnect terminates the current Session which disconnects it from the ngrok cloud service.
-	Disconnect() error
-
-	// Session returns an object describing the connection of the Agent to the ngrok cloud service.
-	Session() (AgentSession, error)
-
-	// Endpoints returns the list of endpoints created by this Agent from calls to either Listen or Forward.
-	Endpoints() []Endpoint
-
-	// Listen creates an Endpoint which returns received connections to the caller via an EndpointListener.
-	Listen(context.Context, ...EndpointOption) (EndpointListener, error)
-
-	// Forward creates an Endpoint which forwards received connections to a target upstream URL.
-	Forward(context.Context, *Upstream, ...EndpointOption) (EndpointForwarder, error)
-}
-
 // Dialer is an interface that is satisfied by net.Dialer or you can specify your
 // own implementation.
 type Dialer interface {
@@ -45,8 +24,8 @@ type Dialer interface {
 	DialContext(ctx context.Context, network, address string) (net.Conn, error)
 }
 
-// agent implements the Agent interface.
-type agent struct {
+// Agent is the main interface for interacting with the ngrok service.
+type Agent struct {
 	mu           sync.RWMutex
 	sess         legacy.Session
 	agentSession *agentSession
@@ -58,13 +37,13 @@ type agent struct {
 }
 
 // NewAgent creates a new Agent object.
-func NewAgent(agentOpts ...AgentOption) (Agent, error) {
+func NewAgent(agentOpts ...AgentOption) (*Agent, error) {
 	opts := defaultAgentOpts()
 	for _, opt := range agentOpts {
 		opt(opts)
 	}
 
-	return &agent{
+	return &Agent{
 		opts:          opts,
 		endpoints:     make([]Endpoint, 0),
 		eventHandlers: opts.eventHandlers,
@@ -73,7 +52,7 @@ func NewAgent(agentOpts ...AgentOption) (Agent, error) {
 
 // Connect begins a new Session by connecting and authenticating to the ngrok
 // cloud service.
-func (a *agent) Connect(ctx context.Context) error {
+func (a *Agent) Connect(ctx context.Context) error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
@@ -167,7 +146,7 @@ func (a *agent) Connect(ctx context.Context) error {
 
 // Disconnect terminates the current Session which disconnects it from the ngrok
 // cloud service.
-func (a *agent) Disconnect() error {
+func (a *Agent) Disconnect() error {
 	// Get what we need under lock
 	a.mu.Lock()
 	sess := a.sess
@@ -196,7 +175,7 @@ func (a *agent) Disconnect() error {
 
 // Session returns an object describing the connection of the Agent to the ngrok
 // cloud service.
-func (a *agent) Session() (AgentSession, error) {
+func (a *Agent) Session() (AgentSession, error) {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 
@@ -207,8 +186,9 @@ func (a *agent) Session() (AgentSession, error) {
 	return a.agentSession, nil
 }
 
-// Endpoints returns the list of endpoints created by this Agent.
-func (a *agent) Endpoints() []Endpoint {
+// Endpoints returns the list of endpoints created by this Agent
+// from calls to either [*Agent.Listen] or [*Agent.Forward].
+func (a *Agent) Endpoints() []Endpoint {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 
@@ -217,7 +197,7 @@ func (a *agent) Endpoints() []Endpoint {
 }
 
 // createListener creates an endpointListener for internal use
-func (a *agent) createListener(ctx context.Context, endpointOpts *endpointOpts) (*endpointListener, error) {
+func (a *Agent) createListener(ctx context.Context, endpointOpts *endpointOpts) (*EndpointListener, error) {
 	// Get the session
 	a.mu.RLock()
 	sess := a.sess
@@ -252,7 +232,7 @@ func (a *agent) createListener(ctx context.Context, endpointOpts *endpointOpts) 
 	}
 
 	// Create endpoint listener
-	endpoint := &endpointListener{
+	endpoint := &EndpointListener{
 		baseEndpoint: baseEndpoint{
 			agent:          a,
 			id:             tunnel.ID(),
@@ -278,8 +258,9 @@ func (a *agent) createListener(ctx context.Context, endpointOpts *endpointOpts) 
 	return endpoint, nil
 }
 
-// Listen creates an EndpointListener.
-func (a *agent) Listen(ctx context.Context, opts ...EndpointOption) (EndpointListener, error) {
+// Listen creates an endpoint which returns received connections to the caller
+// via an [*EndpointListener].
+func (a *Agent) Listen(ctx context.Context, opts ...EndpointOption) (*EndpointListener, error) {
 	// Apply all options
 	endpointOpts := defaultEndpointOpts()
 	for _, opt := range opts {
@@ -301,7 +282,7 @@ func (a *agent) Listen(ctx context.Context, opts ...EndpointOption) (EndpointLis
 }
 
 // ensureConnected handles automatic connection and verifies connection state
-func (a *agent) ensureConnected(ctx context.Context) error {
+func (a *Agent) ensureConnected(ctx context.Context) error {
 	// First check if we're already connected (with a read lock)
 	a.mu.RLock()
 	sessionExists := a.sess != nil
@@ -326,7 +307,7 @@ func (a *agent) ensureConnected(ctx context.Context) error {
 }
 
 // removeEndpoint removes an endpoint from the agent's list
-func (a *agent) removeEndpoint(endpoint Endpoint) {
+func (a *Agent) removeEndpoint(endpoint Endpoint) {
 	// Remove the endpoint from our list under lock
 	a.mu.Lock()
 	for i, e := range a.endpoints {
@@ -339,7 +320,7 @@ func (a *agent) removeEndpoint(endpoint Endpoint) {
 }
 
 // emitEvent sends an event to all registered handlers
-func (a *agent) emitEvent(evt Event) {
+func (a *Agent) emitEvent(evt Event) {
 	a.eventMutex.RLock()
 	handlers := make([]EventHandler, len(a.eventHandlers))
 	copy(handlers, a.eventHandlers)
@@ -354,7 +335,7 @@ func (a *agent) emitEvent(evt Event) {
 
 // createCommandHandler returns a legacy.ServerCommandHandler that delegates to the RPCHandler
 // for the specified RPC method.
-func (a *agent) createCommandHandler(method string) legacy.ServerCommandHandler {
+func (a *Agent) createCommandHandler(method string) legacy.ServerCommandHandler {
 	return func(ctx context.Context, sess legacy.Session) error {
 		if a.opts.rpcHandler == nil {
 			return nil
@@ -382,7 +363,7 @@ func (a *agent) createCommandHandler(method string) legacy.ServerCommandHandler 
 // Forward creates an EndpointForwarder that forwards traffic to the specified upstream.
 // The upstream parameter is required and must be created using WithUpstream().
 // Additional endpoint options can be provided to configure the endpoint.
-func (a *agent) Forward(ctx context.Context, upstream *Upstream, opts ...EndpointOption) (EndpointForwarder, error) {
+func (a *Agent) Forward(ctx context.Context, upstream *Upstream, opts ...EndpointOption) (*EndpointForwarder, error) {
 	// Apply all base options first
 	endpointOpts := defaultEndpointOpts()
 
@@ -425,7 +406,7 @@ func (a *agent) Forward(ctx context.Context, upstream *Upstream, opts ...Endpoin
 	upstreamURL, _ := url.Parse(endpointOpts.upstreamURL)
 
 	// Create the forwarder
-	endpoint := &endpointForwarder{
+	endpoint := &EndpointForwarder{
 		baseEndpoint:            listener.baseEndpoint, // reuse the baseEndpoint from listener
 		listener:                listener,
 		upstreamURL:             *upstreamURL,

--- a/agent.go
+++ b/agent.go
@@ -28,7 +28,7 @@ type Dialer interface {
 type Agent struct {
 	mu           sync.RWMutex
 	sess         legacy.Session
-	agentSession *agentSession
+	agentSession *AgentSession
 	opts         *agentOpts
 	endpoints    []Endpoint
 	// Event handlers registered with this agent
@@ -97,9 +97,9 @@ func (a *Agent) Connect(ctx context.Context) error {
 	}
 
 	// Create our AgentSession wrapper early so we can capture it in closures
-	agentSession := &agentSession{
-		agent:     a,
-		startedAt: time.Now(),
+	agentSession := &AgentSession{
+		Agent:     a,
+		StartedAt: time.Now(),
 	}
 
 	// Hook up connect event
@@ -134,8 +134,8 @@ func (a *Agent) Connect(ctx context.Context) error {
 	}
 
 	// Complete the AgentSession wrapper with session-specific data
-	agentSession.id = sess.AgentSessionID()
-	agentSession.warnings = sess.Warnings()
+	agentSession.ID = sess.AgentSessionID()
+	agentSession.Warnings = sess.Warnings()
 
 	// Store in agent
 	a.sess = sess
@@ -175,15 +175,13 @@ func (a *Agent) Disconnect() error {
 
 // Session returns an object describing the connection of the Agent to the ngrok
 // cloud service.
-func (a *Agent) Session() (AgentSession, error) {
+func (a *Agent) Session() (*AgentSession, error) {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
-
 	if a.sess == nil || a.agentSession == nil {
 		return nil, errors.New("agent not connected")
 	}
-
-	return a.agentSession, nil
+	return a.agentSession.clone(), nil
 }
 
 // Endpoints returns the list of endpoints created by this Agent

--- a/defaults.go
+++ b/defaults.go
@@ -11,11 +11,11 @@ var DefaultAgent, _ = NewAgent(
 )
 
 // Listen is equivalent to DefaultAgent.Listen().
-func Listen(ctx context.Context, opts ...EndpointOption) (EndpointListener, error) {
+func Listen(ctx context.Context, opts ...EndpointOption) (*EndpointListener, error) {
 	return DefaultAgent.Listen(ctx, opts...)
 }
 
 // Forward is sugar for DefaultAgent.Forward().
-func Forward(ctx context.Context, upstream *Upstream, opts ...EndpointOption) (EndpointForwarder, error) {
+func Forward(ctx context.Context, upstream *Upstream, opts ...EndpointOption) (*EndpointForwarder, error) {
 	return DefaultAgent.Forward(ctx, upstream, opts...)
 }

--- a/diagnose.go
+++ b/diagnose.go
@@ -64,26 +64,15 @@ func IsMuxadoDiagnoseFailure(err error) bool {
 	return errors.As(err, &de) && de.Step == "muxado"
 }
 
-// Diagnoser is implemented by Agent types that support pre-connection
-// diagnostic probing. Use a type assertion to access it:
+// Diagnose tests connectivity to addr by probing TCP, TLS, and the Muxado
+// tunnel protocol. It uses the Agent's configured TLS settings, CA roots,
+// and proxy/dialer settings.
 //
-//	d, ok := agent.(ngrok.Diagnoser)
-type Diagnoser interface {
-	Agent
-
-	// Diagnose tests connectivity to addr by probing TCP, TLS, and the Muxado
-	// tunnel protocol. It uses the Agent's configured TLS settings, CA roots,
-	// and proxy/dialer settings.
-	//
-	// If addr is empty, the configured server address is probed.
-	//
-	// This method does NOT establish a persistent session or call Auth. It is
-	// safe to call without affecting any existing connection.
-	Diagnose(ctx context.Context, addr string) (DiagnoseResult, error)
-}
-
-// Diagnose implements Diagnoser.
-func (a *agent) Diagnose(ctx context.Context, addr string) (DiagnoseResult, error) {
+// If addr is empty, the configured server address is probed.
+//
+// This method does NOT establish a persistent session or call Auth. It is
+// safe to call without affecting any existing connection.
+func (a *Agent) Diagnose(ctx context.Context, addr string) (DiagnoseResult, error) {
 	connectAddr := cmp.Or(a.opts.connectURL, "connect.ngrok-agent.com:443")
 	if addr == "" {
 		addr = connectAddr
@@ -110,7 +99,7 @@ func (a *agent) Diagnose(ctx context.Context, addr string) (DiagnoseResult, erro
 
 // buildDiagnosticDialer returns the effective dialer for probes, applying
 // proxy configuration without mutating agent state.
-func (a *agent) buildDiagnosticDialer() (Dialer, error) {
+func (a *Agent) buildDiagnosticDialer() (Dialer, error) {
 	baseDialer := cmp.Or(a.opts.dialer, Dialer(&net.Dialer{}))
 	if a.opts.proxyURL == "" {
 		return baseDialer, nil
@@ -132,7 +121,7 @@ func (a *agent) buildDiagnosticDialer() (Dialer, error) {
 
 // probeAddr runs TCP → TLS → Muxado → SrvInfo for addr and returns a
 // DiagnoseResult on success, or a *DiagnoseError indicating which step failed.
-func (a *agent) probeAddr(ctx context.Context, logger *slog.Logger, dialer Dialer, serverName, addr string) (DiagnoseResult, error) {
+func (a *Agent) probeAddr(ctx context.Context, logger *slog.Logger, dialer Dialer, serverName, addr string) (DiagnoseResult, error) {
 	result := DiagnoseResult{Addr: addr}
 
 	// TCP

--- a/diagnose_test.go
+++ b/diagnose_test.go
@@ -30,10 +30,7 @@ func TestDiagnoseTCPFailure(t *testing.T) {
 	a, err := NewAgent()
 	require.NoError(t, err)
 
-	d, ok := a.(Diagnoser)
-	require.True(t, ok, "agent should implement Diagnoser")
-
-	result, err := d.Diagnose(testcontext.ForTB(t), addr)
+	result, err := a.Diagnose(testcontext.ForTB(t), addr)
 	require.Error(t, err)
 	assert.True(t, IsTCPDiagnoseFailure(err))
 	assert.Equal(t, addr, result.Addr)
@@ -57,9 +54,7 @@ func TestDiagnoseTLSFailure(t *testing.T) {
 	a, err := NewAgent(WithAgentConnectURL(l.Addr().String()))
 	require.NoError(t, err)
 
-	d := a.(Diagnoser)
-
-	result, err := d.Diagnose(testcontext.ForTB(t), l.Addr().String())
+	result, err := a.Diagnose(testcontext.ForTB(t), l.Addr().String())
 	require.Error(t, err)
 	assert.True(t, IsTLSDiagnoseFailure(err))
 	assert.Equal(t, l.Addr().String(), result.Addr)
@@ -118,9 +113,7 @@ func TestDiagnoseMuxadoSuccess(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	d := a.(Diagnoser)
-
-	result, err := d.Diagnose(testcontext.ForTB(t), l.Addr().String())
+	result, err := a.Diagnose(testcontext.ForTB(t), l.Addr().String())
 	require.NoError(t, err)
 	assert.Equal(t, l.Addr().String(), result.Addr)
 	assert.Equal(t, testRegion, result.Region)
@@ -149,12 +142,9 @@ func TestDiagnoseOnline(t *testing.T) {
 	a, err := NewAgent(agentOpts...)
 	require.NoError(t, err)
 
-	d, ok := a.(Diagnoser)
-	require.True(t, ok)
-
 	ctx := testcontext.ForTB(t)
 
-	result, err := d.Diagnose(ctx, serverAddr)
+	result, err := a.Diagnose(ctx, serverAddr)
 	require.NoError(t, err)
 	t.Logf("addr=%s region=%s latency=%s", result.Addr, result.Region, result.Latency)
 	assert.NotEmpty(t, result.Region)

--- a/endpoint.go
+++ b/endpoint.go
@@ -1,65 +1,21 @@
 package ngrok
 
 import (
-	"context"
 	"crypto/tls"
 	"net/url"
 	"sync"
 )
 
-// Endpoint is the interface implemented by both EndpointListener and
-// EndpointForwarder.
+// Endpoint is the interface implemented by both
+// [*EndpointListener] and [*EndpointForwarder].
 type Endpoint interface {
-	// Agent returns the Agent that created this Endpoint.
-	Agent() Agent
-
-	// PoolingEnabled returns whether the endpoint supports pooling set by WithPoolingEnabled.
-	PoolingEnabled() bool
-
-	// Bindings returns the endpoint's bindings set by WithBindings
-	Bindings() []string
-
-	// Close() is equivalent to for CloseWithContext(context.Background())
-	Close() error
-
-	// CloseWithContext closes the endpoint with the provided context.
-	CloseWithContext(context.Context) error
-
-	// Description returns the endpoint's human-readable description set by WithDescription.
-	Description() string
-
-	// Done returns a channel that is closed when the endpoint stops.
-	Done() <-chan struct{}
-
-	// Wait blocks until the endpoint stops.
-	Wait()
-
-	// ID returns the unique endpoint identifier assigned by the ngrok cloud service.
-	ID() string
-
-	// Metadata returns the endpoint's opaque user-defined metadata set by WithMetadata.
-	Metadata() string
-
-	// Name returns the endpoint's human-readable name set by WithName.
-	Name() string
-
-	// Protocol is sugar for URL().Scheme
-	Protocol() string
-
-	// AgentTLSTermination returns the TLS config that the agent uses to terminate TLS connections.
-	AgentTLSTermination() *tls.Config
-
-	// TrafficPolicy returns the traffic policy for the endpoint.
-	TrafficPolicy() string
-
-	// URL returns the Endpoint's URL
-	URL() *url.URL
+	endpoint()
 }
 
 // baseEndpoint implements the common functionality for both EndpointListener and
 // EndpointForwarder.
 type baseEndpoint struct {
-	agent          Agent
+	agent          *Agent
 	name           string
 	poolingEnabled bool
 	bindings       []string
@@ -73,54 +29,69 @@ type baseEndpoint struct {
 	doneOnce       *sync.Once
 }
 
-func (e *baseEndpoint) Agent() Agent {
+func (e *baseEndpoint) endpoint() {}
+
+// Agent returns the [*Agent] that created this Endpoint.
+func (e *baseEndpoint) Agent() *Agent {
 	return e.agent
 }
 
+// PoolingEnabled returns whether the endpoint supports pooling set by WithPoolingEnabled.
 func (e *baseEndpoint) PoolingEnabled() bool {
 	return e.poolingEnabled
 }
 
+// Bindings returns the endpoint's bindings set by WithBindings
 func (e *baseEndpoint) Bindings() []string {
 	return e.bindings
 }
 
+// Description returns the endpoint's human-readable description set by WithDescription.
 func (e *baseEndpoint) Description() string {
 	return e.description
 }
 
+// Done returns a channel that is closed when the endpoint stops.
 func (e *baseEndpoint) Done() <-chan struct{} {
 	return e.doneChannel
 }
 
+// Wait blocks until the endpoint stops.
 func (e *baseEndpoint) Wait() {
 	<-e.doneChannel
 }
 
+// ID returns the unique endpoint identifier assigned by the ngrok cloud service.
 func (e *baseEndpoint) ID() string {
 	return e.id
 }
 
+// Metadata returns the endpoint's opaque user-defined metadata set by WithMetadata.
 func (e *baseEndpoint) Metadata() string {
 	return e.metadata
 }
 
+// Name returns the endpoint's human-readable name set by WithName.
 func (e *baseEndpoint) Name() string {
 	return e.name
 }
 
+// Protocol is sugar for URL().Scheme
 func (e *baseEndpoint) Protocol() string {
 	return e.endpointURL.Scheme
 }
 
+// AgentTLSTermination returns the TLS config that the agent uses to terminate TLS connections.
 func (e *baseEndpoint) AgentTLSTermination() *tls.Config {
 	return e.agentTLSConfig
 }
 
+// TrafficPolicy returns the traffic policy for the endpoint.
 func (e *baseEndpoint) TrafficPolicy() string {
 	return e.trafficPolicy
 }
 
+// URL returns the Endpoint's URL.
 func (e *baseEndpoint) URL() *url.URL {
 	return &e.endpointURL
 }

--- a/events.go
+++ b/events.go
@@ -49,14 +49,14 @@ type EventHandler func(Event)
 // EventAgentConnectSucceeded is emitted when an agent successfully establishes a connection
 type EventAgentConnectSucceeded struct {
 	baseEvent
-	Agent   Agent
+	Agent   *Agent
 	Session AgentSession
 }
 
 // EventAgentDisconnected is emitted when an agent disconnects
 type EventAgentDisconnected struct {
 	baseEvent
-	Agent   Agent
+	Agent   *Agent
 	Session AgentSession
 	Error   error
 }
@@ -64,12 +64,12 @@ type EventAgentDisconnected struct {
 // EventAgentHeartbeatReceived is emitted when a heartbeat is successful
 type EventAgentHeartbeatReceived struct {
 	baseEvent
-	Agent   Agent
+	Agent   *Agent
 	Session AgentSession
 	Latency time.Duration
 }
 
-func newAgentConnectSucceeded(agent Agent, session AgentSession) *EventAgentConnectSucceeded {
+func newAgentConnectSucceeded(agent *Agent, session AgentSession) *EventAgentConnectSucceeded {
 	return &EventAgentConnectSucceeded{
 		baseEvent: baseEvent{
 			Type:       EventTypeAgentConnectSucceeded,
@@ -80,7 +80,7 @@ func newAgentConnectSucceeded(agent Agent, session AgentSession) *EventAgentConn
 	}
 }
 
-func newAgentDisconnected(agent Agent, session AgentSession, err error) *EventAgentDisconnected {
+func newAgentDisconnected(agent *Agent, session AgentSession, err error) *EventAgentDisconnected {
 	return &EventAgentDisconnected{
 		baseEvent: baseEvent{
 			Type:       EventTypeAgentDisconnected,
@@ -92,7 +92,7 @@ func newAgentDisconnected(agent Agent, session AgentSession, err error) *EventAg
 	}
 }
 
-func newAgentHeartbeatReceived(agent Agent, session AgentSession, latency time.Duration) *EventAgentHeartbeatReceived {
+func newAgentHeartbeatReceived(agent *Agent, session AgentSession, latency time.Duration) *EventAgentHeartbeatReceived {
 	return &EventAgentHeartbeatReceived{
 		baseEvent: baseEvent{
 			Type:       EventTypeAgentHeartbeatReceived,

--- a/events.go
+++ b/events.go
@@ -50,14 +50,14 @@ type EventHandler func(Event)
 type EventAgentConnectSucceeded struct {
 	baseEvent
 	Agent   *Agent
-	Session AgentSession
+	Session *AgentSession
 }
 
 // EventAgentDisconnected is emitted when an agent disconnects
 type EventAgentDisconnected struct {
 	baseEvent
 	Agent   *Agent
-	Session AgentSession
+	Session *AgentSession
 	Error   error
 }
 
@@ -65,11 +65,11 @@ type EventAgentDisconnected struct {
 type EventAgentHeartbeatReceived struct {
 	baseEvent
 	Agent   *Agent
-	Session AgentSession
+	Session *AgentSession
 	Latency time.Duration
 }
 
-func newAgentConnectSucceeded(agent *Agent, session AgentSession) *EventAgentConnectSucceeded {
+func newAgentConnectSucceeded(agent *Agent, session *AgentSession) *EventAgentConnectSucceeded {
 	return &EventAgentConnectSucceeded{
 		baseEvent: baseEvent{
 			Type:       EventTypeAgentConnectSucceeded,
@@ -80,7 +80,7 @@ func newAgentConnectSucceeded(agent *Agent, session AgentSession) *EventAgentCon
 	}
 }
 
-func newAgentDisconnected(agent *Agent, session AgentSession, err error) *EventAgentDisconnected {
+func newAgentDisconnected(agent *Agent, session *AgentSession, err error) *EventAgentDisconnected {
 	return &EventAgentDisconnected{
 		baseEvent: baseEvent{
 			Type:       EventTypeAgentDisconnected,
@@ -92,7 +92,7 @@ func newAgentDisconnected(agent *Agent, session AgentSession, err error) *EventA
 	}
 }
 
-func newAgentHeartbeatReceived(agent *Agent, session AgentSession, latency time.Duration) *EventAgentHeartbeatReceived {
+func newAgentHeartbeatReceived(agent *Agent, session *AgentSession, latency time.Duration) *EventAgentHeartbeatReceived {
 	return &EventAgentHeartbeatReceived{
 		baseEvent: baseEvent{
 			Type:       EventTypeAgentHeartbeatReceived,

--- a/events_test.go
+++ b/events_test.go
@@ -38,7 +38,7 @@ func TestBaseEvent(t *testing.T) {
 func TestEventCreation(t *testing.T) {
 	// Create a mock agent and session for testing
 	agent := &Agent{}
-	session := &agentSession{}
+	session := &AgentSession{}
 
 	// Test EventAgentConnectSucceeded creation
 	connectEvent := newAgentConnectSucceeded(agent, session)

--- a/events_test.go
+++ b/events_test.go
@@ -37,7 +37,7 @@ func TestBaseEvent(t *testing.T) {
 
 func TestEventCreation(t *testing.T) {
 	// Create a mock agent and session for testing
-	agent := &agent{}
+	agent := &Agent{}
 	session := &agentSession{}
 
 	// Test EventAgentConnectSucceeded creation

--- a/forwarder.go
+++ b/forwarder.go
@@ -13,28 +13,9 @@ import (
 )
 
 // EndpointForwarder is an Endpoint that forwards traffic to an upstream service.
-type EndpointForwarder interface {
-	Endpoint
-
-	// UpstreamProtocol returns the protocol used to communicate with the upstream server.
-	// This differs from UpstreamURL().Scheme if http2 is used.
-	UpstreamProtocol() string
-
-	// UpstreamURL returns the URL that the endpoint forwards its traffic to.
-	UpstreamURL() url.URL
-
-	// UpstreamTLSClientConfig returns the TLS client configuration used for upstream connections.
-	UpstreamTLSClientConfig() *tls.Config
-
-	// ProxyProtocol returns the PROXY protocol version used for the endpoint.
-	// Returns a ProxyProtoVersion or empty string if not enabled.
-	ProxyProtocol() ProxyProtoVersion
-}
-
-// endpointForwarder implements the EndpointForwarder interface.
-type endpointForwarder struct {
+type EndpointForwarder struct {
 	baseEndpoint
-	listener                *endpointListener
+	listener                *EndpointListener
 	upstreamURL             url.URL
 	upstreamTLSClientConfig *tls.Config
 	upstreamProtocol        string
@@ -43,12 +24,12 @@ type endpointForwarder struct {
 }
 
 // Start begins forwarding connections from the listener to the upstream URL
-func (e *endpointForwarder) start(ctx context.Context) {
+func (e *EndpointForwarder) start(ctx context.Context) {
 	go e.forwardLoop(ctx)
 }
 
 // forwardLoop is the main loop that forwards connections
-func (e *endpointForwarder) forwardLoop(ctx context.Context) {
+func (e *EndpointForwarder) forwardLoop(ctx context.Context) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	for {
@@ -74,7 +55,7 @@ func (e *endpointForwarder) forwardLoop(ctx context.Context) {
 }
 
 // handleConnection processes a single connection
-func (e *endpointForwarder) handleConnection(ctx context.Context, conn net.Conn) {
+func (e *EndpointForwarder) handleConnection(ctx context.Context, conn net.Conn) {
 	start := time.Now()
 	remoteAddr := conn.RemoteAddr().String()
 
@@ -98,13 +79,11 @@ func (e *endpointForwarder) handleConnection(ctx context.Context, conn net.Conn)
 	}
 }
 
-func (e *endpointForwarder) emitConnectionEvent(evt Event) {
-	if a, ok := e.agent.(*agent); ok {
-		a.emitEvent(evt)
-	}
+func (e *EndpointForwarder) emitConnectionEvent(evt Event) {
+	e.agent.emitEvent(evt)
 }
 
-func (e *endpointForwarder) isHTTP() bool {
+func (e *EndpointForwarder) isHTTP() bool {
 	switch strings.ToLower(e.upstreamURL.Scheme) {
 	case "http", "https":
 		return true
@@ -132,7 +111,7 @@ func (c *countingConn) Write(p []byte) (int, error) {
 }
 
 // connectToBackend establishes a connection to the upstream URL
-func (e *endpointForwarder) connectToBackend(ctx context.Context) (net.Conn, error) {
+func (e *EndpointForwarder) connectToBackend(ctx context.Context) (net.Conn, error) {
 	// Parse host and port from URL
 	host := e.upstreamURL.Hostname()
 	port := e.upstreamURL.Port()
@@ -194,7 +173,7 @@ func (e *endpointForwarder) connectToBackend(ctx context.Context) (net.Conn, err
 }
 
 // join copies data bidirectionally between the two connections
-func (e *endpointForwarder) join(left, right net.Conn) {
+func (e *EndpointForwarder) join(left, right net.Conn) {
 	wg := &sync.WaitGroup{}
 	wg.Add(2)
 
@@ -215,11 +194,13 @@ func (e *endpointForwarder) join(left, right net.Conn) {
 	wg.Wait()
 }
 
-func (e *endpointForwarder) Close() error {
+// Close() is equivalent to for CloseWithContext(context.Background())
+func (e *EndpointForwarder) Close() error {
 	return e.CloseWithContext(context.Background())
 }
 
-func (e *endpointForwarder) CloseWithContext(ctx context.Context) error {
+// CloseWithContext closes the endpoint with the provided context.
+func (e *EndpointForwarder) CloseWithContext(ctx context.Context) error {
 	// Close via the listener
 	err := e.listener.CloseWithContext(ctx)
 
@@ -227,22 +208,24 @@ func (e *endpointForwarder) CloseWithContext(ctx context.Context) error {
 }
 
 // UpstreamProtocol returns the protocol used to communicate with the upstream server.
-func (e *endpointForwarder) UpstreamProtocol() string {
+// This differs from UpstreamURL().Scheme if http2 is used.
+func (e *EndpointForwarder) UpstreamProtocol() string {
 	return e.upstreamProtocol
 }
 
 // UpstreamURL returns the URL that the endpoint forwards its traffic to.
-func (e *endpointForwarder) UpstreamURL() url.URL {
+func (e *EndpointForwarder) UpstreamURL() url.URL {
 	return e.upstreamURL
 }
 
 // UpstreamTLSClientConfig returns the TLS client configuration used for upstream connections.
-func (e *endpointForwarder) UpstreamTLSClientConfig() *tls.Config {
+func (e *EndpointForwarder) UpstreamTLSClientConfig() *tls.Config {
 	return e.upstreamTLSClientConfig
 }
 
 // ProxyProtocol returns the PROXY protocol version used for the endpoint.
-func (e *endpointForwarder) ProxyProtocol() ProxyProtoVersion {
+// Returns a ProxyProtoVersion or empty string if not enabled.
+func (e *EndpointForwarder) ProxyProtocol() ProxyProtoVersion {
 	return e.proxyProtocol
 }
 

--- a/httpinspect.go
+++ b/httpinspect.go
@@ -18,7 +18,7 @@ import (
 // It creates an http.Server with a handler that wraps ReverseProxy and a
 // statusCaptureWriter for event emission, then uses httpx.ServeConnServer
 // to serve the single proxy connection without needing a real net.Listener.
-func (e *endpointForwarder) httpServe(proxyConn net.Conn) {
+func (e *EndpointForwarder) httpServe(proxyConn net.Conn) {
 	target := e.upstreamURL
 	transport := e.buildHTTPTransport()
 
@@ -58,7 +58,7 @@ func (e *endpointForwarder) httpServe(proxyConn net.Conn) {
 
 // buildHTTPTransport creates an http.Transport configured with the
 // endpoint's upstream settings
-func (e *endpointForwarder) buildHTTPTransport() *http.Transport {
+func (e *EndpointForwarder) buildHTTPTransport() *http.Transport {
 	tlsConfig := &tls.Config{
 		ServerName: e.upstreamURL.Hostname(),
 	}

--- a/internal/integration_tests/endpoint_closing_test.go
+++ b/internal/integration_tests/endpoint_closing_test.go
@@ -1,11 +1,13 @@
 package integration_tests
 
 import (
+	"net/url"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.ngrok.com/ngrok/v2"
 )
 
 // TestEndpointClosingIntegration tests closing an endpoint while an agent session is live
@@ -22,14 +24,14 @@ func TestEndpointClosingIntegration(t *testing.T) {
 	require.NoError(t, err, "Failed to create listener")
 
 	// Store the endpoint URL for verification
-	endpointURL := listener.URL().String()
-	t.Logf("Created endpoint: %s", endpointURL)
+	wantEndpointURL := listener.URL().String()
+	t.Logf("Created endpoint: %s", wantEndpointURL)
 
 	// Verify the endpoint appears in the agent's endpoints list
 	endpoints := agent.Endpoints()
 	endpointFound := false
 	for _, ep := range endpoints {
-		if ep.URL().String() == endpointURL {
+		if endpointURL(ep).String() == wantEndpointURL {
 			endpointFound = true
 			break
 		}
@@ -58,6 +60,16 @@ func TestEndpointClosingIntegration(t *testing.T) {
 	// Verify the endpoint is removed from the agent's endpoints list
 	endpoints = agent.Endpoints()
 	for _, ep := range endpoints {
-		assert.NotEqual(t, endpointURL, ep.URL().String(), "Endpoint should not be found in agent's endpoints list after closing")
+		assert.NotEqual(t, wantEndpointURL, endpointURL(ep).String(), "Endpoint should not be found in agent's endpoints list after closing")
 	}
+}
+
+func endpointURL(ep ngrok.Endpoint) *url.URL {
+	u, ok := ep.(interface {
+		URL() *url.URL
+	})
+	if !ok {
+		return nil
+	}
+	return u.URL()
 }

--- a/internal/integration_tests/test_utils.go
+++ b/internal/integration_tests/test_utils.go
@@ -27,7 +27,7 @@ func SkipIfOffline(t *testing.T) {
 }
 
 // SetupAgent creates and connects a new agent for testing
-func SetupAgent(t *testing.T) (ngrok.Agent, context.Context) {
+func SetupAgent(t *testing.T) (*ngrok.Agent, context.Context) {
 	// Skip if not running online tests
 	SkipIfOffline(t)
 
@@ -60,7 +60,7 @@ func SetupAgent(t *testing.T) (ngrok.Agent, context.Context) {
 // SetupListener sets up an ngrok listener with the specified options.
 // SetupListener must be called from the goroutine running the test or benchmark.
 // The returned listener will be closed when the test or benchmark function returns.
-func SetupListener(ctx context.Context, tb testing.TB, agent ngrok.Agent, opts ...ngrok.EndpointOption) ngrok.EndpointListener {
+func SetupListener(ctx context.Context, tb testing.TB, agent *ngrok.Agent, opts ...ngrok.EndpointOption) *ngrok.EndpointListener {
 	tb.Helper()
 
 	// Create a listener endpoint

--- a/listener.go
+++ b/listener.go
@@ -8,19 +8,8 @@ import (
 	"golang.ngrok.com/ngrok/v2/internal/legacy"
 )
 
-// EndpointListener is an endpoint that you may treat as a net.Listener.
-type EndpointListener interface {
-	Endpoint
-
-	// Accept returns the next connection received the Endpoint.
-	Accept() (net.Conn, error)
-
-	// Addr() returns where the Endpoint is listening.
-	Addr() net.Addr
-}
-
-// endpointListener implements the EndpointListener interface.
-type endpointListener struct {
+// EndpointListener is an endpoint that you may treat as a [net.Listener].
+type EndpointListener struct {
 	baseEndpoint
 	tunnel legacy.Tunnel
 }
@@ -37,7 +26,8 @@ func wrapConnWithTLS(conn net.Conn, tlsConfig *tls.Config) net.Conn {
 	return tls.Server(conn, tlsConfig)
 }
 
-func (e *endpointListener) Accept() (net.Conn, error) {
+// Accept returns the next connection received the Endpoint.
+func (e *EndpointListener) Accept() (net.Conn, error) {
 	// Accept connection from the tunnel
 	conn, err := e.tunnel.Accept()
 	if err != nil {
@@ -54,22 +44,23 @@ func (e *endpointListener) Accept() (net.Conn, error) {
 	return conn, nil
 }
 
-func (e *endpointListener) Addr() net.Addr {
+// Addr() returns where the Endpoint is listening.
+func (e *EndpointListener) Addr() net.Addr {
 	return e.tunnel.Addr()
 }
 
-func (e *endpointListener) Close() error {
+// Close() is equivalent to for CloseWithContext(context.Background())
+func (e *EndpointListener) Close() error {
 	return e.CloseWithContext(context.Background())
 }
 
-func (e *endpointListener) CloseWithContext(ctx context.Context) error {
+// CloseWithContext closes the endpoint with the provided context.
+func (e *EndpointListener) CloseWithContext(ctx context.Context) error {
 	err := e.tunnel.CloseWithContext(ctx)
 	e.signalDone()
 
 	// Remove from agent
-	if a, ok := e.agent.(*agent); ok {
-		a.removeEndpoint(e)
-	}
+	e.agent.removeEndpoint(e)
 
 	return wrapError(err)
 }

--- a/rpc_handler.go
+++ b/rpc_handler.go
@@ -9,7 +9,7 @@ import (
 // RPCHandler is a function that processes RPC requests from the ngrok service.
 // It receives the context, agent session, and request, and returns an optional
 // response payload and error.
-type RPCHandler func(context.Context, AgentSession, rpc.Request) ([]byte, error)
+type RPCHandler func(context.Context, *AgentSession, rpc.Request) ([]byte, error)
 
 // Private request implementation that satisfies the rpc.Request interface
 type rpcRequest struct {

--- a/session.go
+++ b/session.go
@@ -12,7 +12,7 @@ type AgentSession interface {
 	// Warnings is a list of warnings returned by the ngrok cloud service after the Agent has connected
 	Warnings() []error
 	// Agent returns the agent that started this session
-	Agent() Agent
+	Agent() *Agent
 	// StartedAt returns the time that the AgentSession was connected
 	StartedAt() time.Time
 }
@@ -21,7 +21,7 @@ type AgentSession interface {
 type agentSession struct {
 	id        string
 	warnings  []error
-	agent     Agent
+	agent     *Agent
 	startedAt time.Time
 }
 
@@ -33,7 +33,7 @@ func (s *agentSession) Warnings() []error {
 	return s.warnings
 }
 
-func (s *agentSession) Agent() Agent {
+func (s *agentSession) Agent() *Agent {
 	return s.agent
 }
 

--- a/session.go
+++ b/session.go
@@ -1,42 +1,30 @@
 package ngrok
 
 import (
+	"slices"
 	"time"
 )
 
-// AgentSession represents an active connection from an Agent to the ngrok cloud
-// service.
-type AgentSession interface {
-	// ID returns the server-assigned ID of the agent session
-	ID() string
-	// Warnings is a list of warnings returned by the ngrok cloud service after the Agent has connected
-	Warnings() []error
-	// Agent returns the agent that started this session
-	Agent() *Agent
-	// StartedAt returns the time that the AgentSession was connected
-	StartedAt() time.Time
+// AgentSession describes an active connection from an [*Agent]
+// to the ngrok cloud service.
+type AgentSession struct {
+	// ID is the server-assigned ID of the agent session.
+	ID string
+	// Warnings is a list of warnings returned by the ngrok cloud service
+	// after the Agent has connected.
+	Warnings []error
+	// Agent is the agent that started this session.
+	Agent *Agent
+	// StartedAt returns the time that the session was connected.
+	StartedAt time.Time
 }
 
-// agentSession implements the AgentSession interface.
-type agentSession struct {
-	id        string
-	warnings  []error
-	agent     *Agent
-	startedAt time.Time
-}
-
-func (s *agentSession) ID() string {
-	return s.id
-}
-
-func (s *agentSession) Warnings() []error {
-	return s.warnings
-}
-
-func (s *agentSession) Agent() *Agent {
-	return s.agent
-}
-
-func (s *agentSession) StartedAt() time.Time {
-	return s.startedAt
+func (sess *AgentSession) clone() *AgentSession {
+	if sess == nil {
+		return nil
+	}
+	sessionCopy := new(AgentSession)
+	*sessionCopy = *sess
+	sessionCopy.Warnings = slices.Clone(sess.Warnings)
+	return sessionCopy
 }


### PR DESCRIPTION
**This is a breaking change and should not be merged without a major version bump and a migration strategy from v2.**

Also fix race condition in `AgentSession`.

Part of AGENT-445