### PR TITLE
add support for patching agent endpoints

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -332,6 +332,18 @@ func (a *agent) ensureConnected(ctx context.Context) error {
 	return nil
 }
 
+// patchTunnelState sends a PatchTunnelState muxado message over the active
+// session to propagate metadata changes to the backend.
+func (a *agent) patchTunnelState(_ context.Context, tunnelID string, name, description, metadata *string, poolingEnabled *bool) error {
+	a.mu.RLock()
+	sess := a.sess
+	a.mu.RUnlock()
+	if sess == nil {
+		return fmt.Errorf("agent not connected")
+	}
+	return sess.PatchTunnelState(tunnelID, name, description, metadata, poolingEnabled)
+}
+
 // removeEndpoint removes an endpoint from the agent's list
 func (a *agent) removeEndpoint(endpoint Endpoint) {
 	// Remove the endpoint from our list under lock
@@ -435,12 +447,12 @@ func (a *agent) Forward(ctx context.Context, upstream *Upstream, opts ...Endpoin
 	endpoint := &endpointForwarder{
 		baseEndpoint:            listener.baseEndpoint, // reuse the baseEndpoint from listener
 		listener:                listener,
-		upstreamURL:             *upstreamURL,
 		upstreamProtocol:        endpointOpts.upstreamProtocol,
 		upstreamTLSClientConfig: endpointOpts.upstreamTLSClientConfig,
 		proxyProtocol:           upstream.proxyProto,
 		upstreamDialer:          upstream.dialer,
 	}
+	endpoint.upstreamURL.Store(upstreamURL)
 
 	// Start the forwarding process
 	endpoint.start(ctx)

--- a/agent.go
+++ b/agent.go
@@ -332,8 +332,6 @@ func (a *agent) ensureConnected(ctx context.Context) error {
 	return nil
 }
 
-// patchTunnelState sends a PatchTunnelState muxado message over the active
-// session to propagate metadata changes to the backend.
 func (a *agent) patchTunnelState(_ context.Context, tunnelID string, name, description, metadata *string, poolingEnabled *bool) error {
 	a.mu.RLock()
 	sess := a.sess

--- a/endpoint.go
+++ b/endpoint.go
@@ -73,12 +73,8 @@ type Endpoint interface {
 // EndpointForwarder.
 type baseEndpoint struct {
 	agent           Agent
-	name            string
-	poolingEnabled  bool
-	bindings        []string
-	description     string
 	id              string
-	metadata        string
+	bindings        []string
 	agentTLSConfig  *tls.Config // TLS config for termination
 	trafficPolicy   string
 	endpointURL     url.URL
@@ -88,6 +84,13 @@ type baseEndpoint struct {
 	updatedAt       time.Time
 	tunnelSessionID string
 	tunnelID        string
+
+	// mu protects the following mutable fields
+	mu             sync.RWMutex
+	name           string
+	description    string
+	metadata       string
+	poolingEnabled bool
 }
 
 func (e *baseEndpoint) Agent() Agent {
@@ -95,6 +98,8 @@ func (e *baseEndpoint) Agent() Agent {
 }
 
 func (e *baseEndpoint) PoolingEnabled() bool {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
 	return e.poolingEnabled
 }
 
@@ -103,6 +108,8 @@ func (e *baseEndpoint) Bindings() []string {
 }
 
 func (e *baseEndpoint) Description() string {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
 	return e.description
 }
 
@@ -119,11 +126,32 @@ func (e *baseEndpoint) ID() string {
 }
 
 func (e *baseEndpoint) Metadata() string {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
 	return e.metadata
 }
 
 func (e *baseEndpoint) Name() string {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
 	return e.name
+}
+
+func (e *baseEndpoint) update(name, description, metadata *string, poolingEnabled *bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if name != nil {
+		e.name = *name
+	}
+	if description != nil {
+		e.description = *description
+	}
+	if metadata != nil {
+		e.metadata = *metadata
+	}
+	if poolingEnabled != nil {
+		e.poolingEnabled = *poolingEnabled
+	}
 }
 
 func (e *baseEndpoint) Protocol() string {

--- a/endpoint.go
+++ b/endpoint.go
@@ -73,8 +73,12 @@ type Endpoint interface {
 // EndpointForwarder.
 type baseEndpoint struct {
 	agent           Agent
-	id              string
+	name            string
+	poolingEnabled  bool
 	bindings        []string
+	description     string
+	id              string
+	metadata        string
 	agentTLSConfig  *tls.Config // TLS config for termination
 	trafficPolicy   string
 	endpointURL     url.URL
@@ -84,13 +88,6 @@ type baseEndpoint struct {
 	updatedAt       time.Time
 	tunnelSessionID string
 	tunnelID        string
-
-	// mu protects the following mutable fields
-	mu             sync.RWMutex
-	name           string
-	description    string
-	metadata       string
-	poolingEnabled bool
 }
 
 func (e *baseEndpoint) Agent() Agent {
@@ -98,8 +95,6 @@ func (e *baseEndpoint) Agent() Agent {
 }
 
 func (e *baseEndpoint) PoolingEnabled() bool {
-	e.mu.RLock()
-	defer e.mu.RUnlock()
 	return e.poolingEnabled
 }
 
@@ -108,8 +103,6 @@ func (e *baseEndpoint) Bindings() []string {
 }
 
 func (e *baseEndpoint) Description() string {
-	e.mu.RLock()
-	defer e.mu.RUnlock()
 	return e.description
 }
 
@@ -126,20 +119,14 @@ func (e *baseEndpoint) ID() string {
 }
 
 func (e *baseEndpoint) Metadata() string {
-	e.mu.RLock()
-	defer e.mu.RUnlock()
 	return e.metadata
 }
 
 func (e *baseEndpoint) Name() string {
-	e.mu.RLock()
-	defer e.mu.RUnlock()
 	return e.name
 }
 
 func (e *baseEndpoint) update(name, description, metadata *string, poolingEnabled *bool) {
-	e.mu.Lock()
-	defer e.mu.Unlock()
 	if name != nil {
 		e.name = *name
 	}

--- a/forwarder.go
+++ b/forwarder.go
@@ -23,6 +23,14 @@ type EndpointForwarder interface {
 	// UpstreamURL returns the URL that the endpoint forwards its traffic to.
 	UpstreamURL() url.URL
 
+	// UpdateUpstream atomically updates the upstream URL that connections are forwarded to.
+	// Connections already in progress are not affected. Only new connections use the new URL.
+	UpdateUpstream(u url.URL)
+
+	// Update applies a partial update to the endpoint's mutable metadata fields
+	// and propagates the change to the ngrok backend over the active session.
+	Update(ctx context.Context, name, description, metadata *string, poolingEnabled *bool) error
+
 	// UpstreamTLSClientConfig returns the TLS client configuration used for upstream connections.
 	UpstreamTLSClientConfig() *tls.Config
 
@@ -35,7 +43,7 @@ type EndpointForwarder interface {
 type endpointForwarder struct {
 	baseEndpoint
 	listener                *endpointListener
-	upstreamURL             url.URL
+	upstreamURL             atomic.Pointer[url.URL]
 	upstreamTLSClientConfig *tls.Config
 	upstreamProtocol        string
 	proxyProtocol           ProxyProtoVersion
@@ -105,7 +113,7 @@ func (e *endpointForwarder) emitConnectionEvent(evt Event) {
 }
 
 func (e *endpointForwarder) isHTTP() bool {
-	switch strings.ToLower(e.upstreamURL.Scheme) {
+	switch strings.ToLower(e.upstreamURL.Load().Scheme) {
 	case "http", "https":
 		return true
 	default:
@@ -133,15 +141,17 @@ func (c *countingConn) Write(p []byte) (int, error) {
 
 // connectToBackend establishes a connection to the upstream URL
 func (e *endpointForwarder) connectToBackend(ctx context.Context) (net.Conn, error) {
+	u := e.upstreamURL.Load()
+
 	// Parse host and port from URL
-	host := e.upstreamURL.Hostname()
-	port := e.upstreamURL.Port()
+	host := u.Hostname()
+	port := u.Port()
 	if port == "" {
 		// Default ports based on scheme
 		switch {
-		case usesTLS(e.upstreamURL.Scheme):
+		case usesTLS(u.Scheme):
 			port = "443"
-		case strings.ToLower(e.upstreamURL.Scheme) == "http":
+		case strings.ToLower(u.Scheme) == "http":
 			port = "80"
 		default:
 			port = "80" // Default fallback
@@ -168,9 +178,9 @@ func (e *endpointForwarder) connectToBackend(ctx context.Context) (net.Conn, err
 	}
 
 	// For HTTPS/TLS upstreams, establish TLS
-	if usesTLS(e.upstreamURL.Scheme) {
+	if usesTLS(u.Scheme) {
 		config := &tls.Config{
-			ServerName: e.upstreamURL.Hostname(),
+			ServerName: u.Hostname(),
 		}
 
 		// Use custom TLS client config if provided
@@ -178,7 +188,7 @@ func (e *endpointForwarder) connectToBackend(ctx context.Context) (net.Conn, err
 			// Use the provided config as a base, but ensure ServerName is set
 			config = e.upstreamTLSClientConfig.Clone()
 			if config.ServerName == "" {
-				config.ServerName = e.upstreamURL.Hostname()
+				config.ServerName = u.Hostname()
 			}
 		}
 
@@ -233,7 +243,24 @@ func (e *endpointForwarder) UpstreamProtocol() string {
 
 // UpstreamURL returns the URL that the endpoint forwards its traffic to.
 func (e *endpointForwarder) UpstreamURL() url.URL {
-	return e.upstreamURL
+	return *e.upstreamURL.Load()
+}
+
+// UpdateUpstream atomically updates the upstream URL that connections are forwarded to.
+func (e *endpointForwarder) UpdateUpstream(u url.URL) {
+	e.upstreamURL.Store(&u)
+}
+
+// Update applies a partial update to the endpoint's mutable metadata fields
+// and propagates the change to the ngrok backend over the active session.
+func (e *endpointForwarder) Update(ctx context.Context, name, description, metadata *string, poolingEnabled *bool) error {
+	if a, ok := e.agent.(*agent); ok {
+		if err := a.patchTunnelState(ctx, e.tunnelID, name, description, metadata, poolingEnabled); err != nil {
+			return err
+		}
+	}
+	e.baseEndpoint.update(name, description, metadata, poolingEnabled)
+	return nil
 }
 
 // UpstreamTLSClientConfig returns the TLS client configuration used for upstream connections.

--- a/forwarder.go
+++ b/forwarder.go
@@ -23,6 +23,22 @@ type EndpointForwarder interface {
 	// UpstreamURL returns the URL that the endpoint forwards its traffic to.
 	UpstreamURL() url.URL
 
+	// UpstreamTLSClientConfig returns the TLS client configuration used for upstream connections.
+	UpstreamTLSClientConfig() *tls.Config
+
+	// ProxyProtocol returns the PROXY protocol version used for the endpoint.
+	// Returns a ProxyProtoVersion or empty string if not enabled.
+	ProxyProtocol() ProxyProtoVersion
+}
+
+// UpdateableEndpointForwarder is implemented by EndpointForwarder types that support
+// live updates to the upstream URL and mutable metadata fields. Use a type assertion
+// to access it:
+//
+//	u, ok := forwarder.(ngrok.UpdateableEndpointForwarder)
+type UpdateableEndpointForwarder interface {
+	EndpointForwarder
+
 	// UpdateUpstream atomically updates the upstream URL that connections are forwarded to.
 	// Connections already in progress are not affected. Only new connections use the new URL.
 	UpdateUpstream(u url.URL)
@@ -30,13 +46,6 @@ type EndpointForwarder interface {
 	// Update applies a partial update to the endpoint's mutable metadata fields
 	// and propagates the change to the ngrok backend over the active session.
 	Update(ctx context.Context, name, description, metadata *string, poolingEnabled *bool) error
-
-	// UpstreamTLSClientConfig returns the TLS client configuration used for upstream connections.
-	UpstreamTLSClientConfig() *tls.Config
-
-	// ProxyProtocol returns the PROXY protocol version used for the endpoint.
-	// Returns a ProxyProtoVersion or empty string if not enabled.
-	ProxyProtocol() ProxyProtoVersion
 }
 
 // endpointForwarder implements the EndpointForwarder interface.

--- a/forwarder.go
+++ b/forwarder.go
@@ -50,7 +50,6 @@ type endpointForwarder struct {
 	upstreamDialer          Dialer
 }
 
-
 // Start begins forwarding connections from the listener to the upstream URL
 func (e *endpointForwarder) start(ctx context.Context) {
 	go e.forwardLoop(ctx)

--- a/forwarder.go
+++ b/forwarder.go
@@ -246,13 +246,10 @@ func (e *endpointForwarder) UpstreamURL() url.URL {
 	return *e.upstreamURL.Load()
 }
 
-// UpdateUpstream atomically updates the upstream URL that connections are forwarded to.
 func (e *endpointForwarder) UpdateUpstream(u url.URL) {
 	e.upstreamURL.Store(&u)
 }
 
-// Update applies a partial update to the endpoint's mutable metadata fields
-// and propagates the change to the ngrok backend over the active session.
 func (e *endpointForwarder) Update(ctx context.Context, name, description, metadata *string, poolingEnabled *bool) error {
 	if a, ok := e.agent.(*agent); ok {
 		if err := a.patchTunnelState(ctx, e.tunnelID, name, description, metadata, poolingEnabled); err != nil {

--- a/forwarder.go
+++ b/forwarder.go
@@ -50,6 +50,7 @@ type endpointForwarder struct {
 	upstreamDialer          Dialer
 }
 
+
 // Start begins forwarding connections from the listener to the upstream URL
 func (e *endpointForwarder) start(ctx context.Context) {
 	go e.forwardLoop(ctx)
@@ -256,7 +257,7 @@ func (e *endpointForwarder) Update(ctx context.Context, name, description, metad
 			return err
 		}
 	}
-	e.baseEndpoint.update(name, description, metadata, poolingEnabled)
+	e.update(name, description, metadata, poolingEnabled)
 	return nil
 }
 

--- a/httpinspect.go
+++ b/httpinspect.go
@@ -19,12 +19,12 @@ import (
 // statusCaptureWriter for event emission, then uses httpx.ServeConnServer
 // to serve the single proxy connection without needing a real net.Listener.
 func (e *endpointForwarder) httpServe(proxyConn net.Conn) {
-	target := e.upstreamURL
+	target := e.upstreamURL.Load()
 	transport := e.buildHTTPTransport()
 
 	rp := &httputil.ReverseProxy{
 		Rewrite: func(pr *httputil.ProxyRequest) {
-			pr.SetURL(&target)
+			pr.SetURL(target)
 			// Preserve the original Host header from the inbound request
 			pr.Out.Host = pr.In.Host
 		},
@@ -59,13 +59,14 @@ func (e *endpointForwarder) httpServe(proxyConn net.Conn) {
 // buildHTTPTransport creates an http.Transport configured with the
 // endpoint's upstream settings
 func (e *endpointForwarder) buildHTTPTransport() *http.Transport {
+	u := e.upstreamURL.Load()
 	tlsConfig := &tls.Config{
-		ServerName: e.upstreamURL.Hostname(),
+		ServerName: u.Hostname(),
 	}
 	if e.upstreamTLSClientConfig != nil {
 		tlsConfig = e.upstreamTLSClientConfig.Clone()
 		if tlsConfig.ServerName == "" {
-			tlsConfig.ServerName = e.upstreamURL.Hostname()
+			tlsConfig.ServerName = u.Hostname()
 		}
 	}
 

--- a/internal/legacy/session.go
+++ b/internal/legacy/session.go
@@ -45,6 +45,9 @@ type Session interface {
 	// Warnings returns a list of warnings generated for the session on connect/auth
 	Warnings() []error
 
+	// PatchTunnelState sends a muxado request to update mutable fields on a tunnel
+	PatchTunnelState(tunnelID string, name, description, metadata *string, poolingEnabled *bool) error
+
 	// Close ends the ngrok session. All Tunnel objects created by Listen
 	// on this session will be closed.
 	Close() error
@@ -741,6 +744,10 @@ func (s *sessionImpl) Warnings() []error {
 		return []error{deprecated}
 	}
 	return nil
+}
+
+func (s *sessionImpl) PatchTunnelState(tunnelID string, name, description, metadata *string, poolingEnabled *bool) error {
+	return s.inner().PatchTunnelState(tunnelID, name, description, metadata, poolingEnabled)
 }
 
 func (s *sessionImpl) Listen(ctx context.Context, cfg config.Tunnel) (Tunnel, error) {

--- a/internal/tunnel/client/raw_session.go
+++ b/internal/tunnel/client/raw_session.go
@@ -21,6 +21,7 @@ type RawSession interface {
 	Listen(proto string, opts any, extra proto.BindExtra, id string, forwardsTo string, forwardsProto string) (proto.BindResp, error)
 	ListenLabel(labels map[string]string, metadata string, forwardsTo string, forwardsProto string) (proto.StartTunnelWithLabelResp, error)
 	Unlisten(id string) (proto.UnbindResp, error)
+	PatchTunnelState(id string, name, description, metadata *string, poolingEnabled *bool) (proto.PatchTunnelStateResp, error)
 	Accept() (netx.LoggedConn, error)
 
 	SrvInfo() (proto.SrvInfoResp, error)
@@ -134,6 +135,23 @@ func (s *rawSession) ListenLabel(labels map[string]string, metadata string, forw
 func (s *rawSession) Unlisten(id string) (resp proto.UnbindResp, err error) {
 	req := proto.Unbind{ClientID: id}
 	err = s.rpc(proto.UnbindReq, &req, &resp)
+	return
+}
+
+// PatchTunnelState sends a patch message to the server to update mutable fields
+// on a bound tunnel without unbinding and rebinding.
+func (s *rawSession) PatchTunnelState(tunnelID string, name, description, metadata *string, poolingEnabled *bool) (resp proto.PatchTunnelStateResp, err error) {
+	req := proto.PatchTunnelState{
+		TunnelID:       tunnelID,
+		Name:           name,
+		Description:    description,
+		Metadata:       metadata,
+		PoolingEnabled: poolingEnabled,
+	}
+	err = s.rpc(proto.PatchTunnelStateReq, &req, &resp)
+	if err == nil && resp.Error != "" {
+		err = proto.StringError(resp.Error)
+	}
 	return
 }
 

--- a/internal/tunnel/client/raw_session.go
+++ b/internal/tunnel/client/raw_session.go
@@ -138,8 +138,6 @@ func (s *rawSession) Unlisten(id string) (resp proto.UnbindResp, err error) {
 	return
 }
 
-// PatchTunnelState sends a patch message to the server to update mutable fields
-// on a bound tunnel without unbinding and rebinding.
 func (s *rawSession) PatchTunnelState(tunnelID string, name, description, metadata *string, poolingEnabled *bool) (resp proto.PatchTunnelStateResp, err error) {
 	req := proto.PatchTunnelState{
 		TunnelID:       tunnelID,

--- a/internal/tunnel/client/reconnecting.go
+++ b/internal/tunnel/client/reconnecting.go
@@ -60,6 +60,13 @@ func (s *swapRaw) Unlisten(url string) (resp proto.UnbindResp, err error) {
 	return proto.UnbindResp{}, ErrSessionNotReady
 }
 
+func (s *swapRaw) PatchTunnelState(tunnelID string, name, description, metadata *string, poolingEnabled *bool) (resp proto.PatchTunnelStateResp, err error) {
+	if raw := s.get(); raw != nil {
+		return raw.PatchTunnelState(tunnelID, name, description, metadata, poolingEnabled)
+	}
+	return proto.PatchTunnelStateResp{}, ErrSessionNotReady
+}
+
 func (s *swapRaw) SrvInfo() (resp proto.SrvInfoResp, err error) {
 	if raw := s.get(); raw != nil {
 		return raw.SrvInfo()
@@ -211,6 +218,13 @@ func (s *reconnectingSession) listenTunnel(listen func(*session) (Tunnel, error)
 		return tun, nil
 	}
 	return nil, ErrSessionNotReady
+}
+
+func (s *reconnectingSession) PatchTunnelState(tunnelID string, name, description, metadata *string, poolingEnabled *bool) error {
+	if sess := s.firstSession(); sess != nil {
+		return sess.PatchTunnelState(tunnelID, name, description, metadata, poolingEnabled)
+	}
+	return ErrSessionNotReady
 }
 
 func (s *reconnectingSession) SrvInfo() (resp proto.SrvInfoResp, err error) {

--- a/internal/tunnel/client/session.go
+++ b/internal/tunnel/client/session.go
@@ -58,6 +58,9 @@ type Session interface {
 	// ListenTLS listens on a remote TLS endpoint
 	ListenTLS(opts *proto.TLSEndpoint, extra proto.BindExtra, forwardsTo string) (Tunnel, error)
 
+	// PatchTunnelState sends a muxado request to the server to update mutable fields on a tunnel
+	PatchTunnelState(tunnelID string, name, description, metadata *string, poolingEnabled *bool) error
+
 	SrvInfo() (proto.SrvInfoResp, error)
 
 	// Send a muxado heartbeat and record the latency
@@ -179,6 +182,17 @@ func (s *session) ListenSSH(opts *proto.SSHOptions, extra proto.BindExtra, forwa
 
 func (s *session) SrvInfo() (proto.SrvInfoResp, error) {
 	return s.raw.SrvInfo()
+}
+
+func (s *session) PatchTunnelState(tunnelID string, name, description, metadata *string, poolingEnabled *bool) error {
+	resp, err := s.raw.PatchTunnelState(tunnelID, name, description, metadata, poolingEnabled)
+	if err != nil {
+		return err
+	}
+	if resp.Error != "" {
+		return proto.StringError(resp.Error)
+	}
+	return nil
 }
 
 func (s *session) CloseTunnel(clientId string, err error) error {

--- a/internal/tunnel/client/session.go
+++ b/internal/tunnel/client/session.go
@@ -185,14 +185,8 @@ func (s *session) SrvInfo() (proto.SrvInfoResp, error) {
 }
 
 func (s *session) PatchTunnelState(tunnelID string, name, description, metadata *string, poolingEnabled *bool) error {
-	resp, err := s.raw.PatchTunnelState(tunnelID, name, description, metadata, poolingEnabled)
-	if err != nil {
-		return err
-	}
-	if resp.Error != "" {
-		return proto.StringError(resp.Error)
-	}
-	return nil
+	_, err := s.raw.PatchTunnelState(tunnelID, name, description, metadata, poolingEnabled)
+	return err
 }
 
 func (s *session) CloseTunnel(clientId string, err error) error {

--- a/internal/tunnel/proto/msg.go
+++ b/internal/tunnel/proto/msg.go
@@ -31,6 +31,9 @@ const (
 
 	// sent from client to the server
 	SrvInfoReq ReqType = 8
+
+	// sent from client to the server to patch mutable tunnel state
+	PatchTunnelStateReq ReqType = 10
 )
 
 var Version = []string{"3", "2"} // integers in priority order
@@ -440,4 +443,19 @@ type SrvInfo struct{}
 
 type SrvInfoResp struct {
 	Region string
+}
+
+// PatchTunnelState is sent from the client to the server to update mutable
+// fields on a bound tunnel without unbinding and rebinding.
+type PatchTunnelState struct {
+	TunnelID       string  `json:"TunnelId"`
+	Name           *string `json:"Name,omitempty"`
+	Description    *string `json:"Description,omitempty"`
+	Metadata       *string `json:"Metadata,omitempty"`
+	PoolingEnabled *bool   `json:"PoolingEnabled,omitempty"`
+}
+
+// PatchTunnelStateResp is the server's reply to a PatchTunnelState request.
+type PatchTunnelStateResp struct {
+	Error string
 }

--- a/internal/tunnel/proto/msg.go
+++ b/internal/tunnel/proto/msg.go
@@ -21,6 +21,7 @@ const (
 	BindReq                 ReqType = 1
 	UnbindReq               ReqType = 2
 	StartTunnelWithLabelReq ReqType = 7
+	PatchTunnelStateReq     ReqType = 10
 
 	// sent from the server to the client
 	ProxyReq      ReqType = 3
@@ -31,9 +32,6 @@ const (
 
 	// sent from client to the server
 	SrvInfoReq ReqType = 8
-
-	// sent from client to the server to patch mutable tunnel state
-	PatchTunnelStateReq ReqType = 10
 )
 
 var Version = []string{"3", "2"} // integers in priority order


### PR DESCRIPTION
adds Update and UpdateUpstream to EndpointForwarder, allowing callers to mutate a running endpoint's metadata (name, description, metadata, pooling) and upstream URL without tearing down and rebinding the tunnel