### PR TITLE
privatedial: reconnect sessions after drain

### DIFF
--- a/privatedial/client.go
+++ b/privatedial/client.go
@@ -1,18 +1,22 @@
 // Package privatedial implements a client to allow dialing private ngrok
 // endpoints. It authenticates with an API Key as its authtoken and then multiplexes
 // per-target net.Conn streams over a single HTTP/2 or HTTP/3
-// connection.
+// connection. A Session transparently reconnects on server drain or abrupt
+// control-stream failure; new Dial calls follow the freshest underlying
+// transport while in-flight streams ride out the server-advertised drain grace
+// period on the old one.
 package privatedial
 
 import (
 	"bufio"
 	"context"
-	"crypto/rand"
+	cryptorand "crypto/rand"
 	"crypto/tls"
 	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
+	mathrand "math/rand/v2"
 	"net"
 	"net/http"
 	"net/url"
@@ -20,7 +24,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -63,7 +66,7 @@ func (p Protocol) String() string {
 }
 
 const (
-	// dialTimeout bounds a single connection attempt during the race.
+	// dialTimeout bounds a single connection attempt during the race or reconnect.
 	dialTimeout = 3 * time.Second
 	// quicHeadStart is how long the QUIC attempt runs alone before the
 	// HTTP/2 attempt is staggered in. If QUIC completes within this window
@@ -93,12 +96,62 @@ func getStickyProtocol() Protocol {
 	return stickyProtocol
 }
 
-// roundTripCloser is the subset of *http2.Transport / *http3.Transport the
-// session relies on. Holding the transport behind this interface lets a
-// single Session implementation drive either protocol.
+// roundTripCloser is the subset of transport behavior the session relies on.
+// Holding the transport behind this interface lets a single Session
+// implementation drive either protocol.
 type roundTripCloser interface {
 	RoundTrip(*http.Request) (*http.Response, error)
 	CloseIdleConnections()
+}
+
+type requestReserver interface {
+	ReserveNewRequest() bool
+}
+
+type closeTransport interface {
+	Close() error
+}
+
+type sessionTimer interface {
+	C() <-chan time.Time
+	Stop() bool
+}
+
+type sessionClock interface {
+	NewTimer(time.Duration) sessionTimer
+}
+
+type realClock struct{}
+
+func (realClock) NewTimer(d time.Duration) sessionTimer {
+	return realTimer{timer: time.NewTimer(d)}
+}
+
+type realTimer struct {
+	timer *time.Timer
+}
+
+func (t realTimer) C() <-chan time.Time { return t.timer.C }
+func (t realTimer) Stop() bool          { return t.timer.Stop() }
+
+type h2ClientConnTransport struct {
+	cc *http2.ClientConn
+}
+
+func (t *h2ClientConnTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return t.cc.RoundTrip(req)
+}
+
+func (t *h2ClientConnTransport) ReserveNewRequest() bool {
+	return t.cc.ReserveNewRequest()
+}
+
+func (t *h2ClientConnTransport) CloseIdleConnections() {
+	_ = t.Close()
+}
+
+func (t *h2ClientConnTransport) Close() error {
+	return t.cc.Close()
 }
 
 // protodelimUnmarshaler caps inbound server frames. The server only sends
@@ -198,12 +251,16 @@ func (c *Client) serverNameFor(addr string) string {
 
 // OpenSession establishes a single connection to the server, opens the
 // control stream (/session), authenticates, and returns a Session. The
-// caller must Close the Session to release the connection.
+// caller must Close the Session to release the connection. The Session
+// reconnects on server PleaseDrain or abrupt control-stream failure.
 //
 // Transport selection follows the spec's Happy-Eyeballs-like algorithm: by
 // default it races HTTP/3 (QUIC) against HTTP/2, preferring QUIC, and
 // remembers the winning protocol process-wide so later sessions skip the
 // race. ClientOpts.ForceProtocol overrides this.
+//
+// The caller's ctx scopes the initial handshake only. Once OpenSession returns,
+// canceling ctx has no effect on the Session.
 func (c *Client) OpenSession(ctx context.Context) (*Session, error) {
 	proto := c.opts.ForceProtocol
 	if proto == ProtocolAuto {
@@ -289,7 +346,11 @@ func (c *Client) race(ctx context.Context) (*Session, error) {
 			pendingQuic = nil
 			if r.err == nil {
 				quicCancel()
-				closeLoser(h2Ch, h2Cancel)
+				if h2Done {
+					h2Cancel()
+				} else {
+					closeLoser(h2Ch, h2Cancel)
+				}
 				setStickyProtocol(ProtocolQUIC)
 				return r.sess, nil
 			}
@@ -298,7 +359,11 @@ func (c *Client) race(ctx context.Context) (*Session, error) {
 			h2Done = true
 			if r.err == nil {
 				h2Cancel()
-				closeLoser(quicCh, quicCancel)
+				if quicDone {
+					quicCancel()
+				} else {
+					closeLoser(quicCh, quicCancel)
+				}
 				setStickyProtocol(ProtocolH2)
 				return r.sess, nil
 			}
@@ -314,83 +379,66 @@ func (c *Client) race(ctx context.Context) (*Session, error) {
 // openProtocol builds the transport for p and runs the /session handshake
 // over it.
 func (c *Client) openProtocol(ctx context.Context, p Protocol) (*Session, error) {
-	var (
-		sess *Session
-		err  error
-	)
-	switch p {
-	case ProtocolQUIC:
-		sess, err = c.openSessionWith(ctx, c.newH3Transport(), c.opts.QUICServerAddr)
-	case ProtocolH2:
-		sess, err = c.openSessionWith(ctx, c.newH2Transport(), c.opts.H2ServerAddr)
-	default:
-		return nil, fmt.Errorf("private-dial: unsupported protocol %d", p)
-	}
+	first, err := c.openConn(ctx, p)
 	if err != nil {
 		return nil, err
 	}
-	sess.proto = p
-	return sess, nil
-}
 
-// tlsConfigFor clones the configured TLS settings and pins them for the
-// given server address and ALPN protocol.
-func (c *Client) tlsConfigFor(serverAddr string, nextProtos ...string) *tls.Config {
-	tlsCfg := &tls.Config{}
-	if c.opts.TLSConfig != nil {
-		tlsCfg = c.opts.TLSConfig.Clone()
-	}
-	tlsCfg.ServerName = c.serverNameFor(serverAddr)
-	tlsCfg.NextProtos = nextProtos
-	if tlsCfg.MinVersion == 0 {
-		tlsCfg.MinVersion = tls.VersionTLS13
-	}
-	return tlsCfg
-}
-
-// newH2Transport builds the HTTP/2 transport.
-//
-// A single *http2.Transport pinned to a single net.Conn. http2 will
-// multiplex all streams over that one conn, which matches the server's
-// per-conn session model.
-//
-// ReadIdleTimeout + PingTimeout enable h2 keepalive PINGs so a dead
-// peer is detected at the transport layer. Without this, a stalled
-// peer can park indefinite Writes on the request body pipe (see
-// sendControlFrame). With keepalive, h2 closes the conn on missed
-// PING, which closes the body reader and unblocks stuck writers.
-func (c *Client) newH2Transport() roundTripCloser {
-	return &http2.Transport{
-		TLSClientConfig: c.tlsConfigFor(c.opts.H2ServerAddr, "h2"),
-		AllowHTTP:       false,
-		ReadIdleTimeout: 30 * time.Second,
-		PingTimeout:     15 * time.Second,
-	}
-}
-
-// newH3Transport builds the HTTP/3 (QUIC) transport. KeepAlivePeriod is the
-// QUIC analogue of the h2 keepalive PINGs: it keeps the single multiplexing
-// connection alive and surfaces a dead peer to stuck stream writers.
-func (c *Client) newH3Transport() roundTripCloser {
-	return &http3.Transport{
-		TLSClientConfig: c.tlsConfigFor(c.opts.QUICServerAddr, "h3"),
-		QUICConfig: &quic.Config{
-			KeepAlivePeriod: 30 * time.Second,
+	sessCtx, cancel := context.WithCancel(context.Background())
+	s := &Session{
+		ctx:         sessCtx,
+		cancel:      cancel,
+		proto:       p,
+		ready:       make(chan struct{}),
+		current:     first,
+		drainCh:     make(chan struct{}),
+		serverErrCh: make(chan error, 1),
+		openFn: func(ctx context.Context) (*sessionConn, error) {
+			return c.openConn(ctx, p)
 		},
 	}
+	go s.supervise()
+	return s, nil
 }
 
-// openSessionWith runs the /session handshake over transport (reaching
-// serverAddr) and returns the authenticated Session.
-func (c *Client) openSessionWith(ctx context.Context, transport roundTripCloser, serverAddr string) (*Session, error) {
+func (c *Client) openConn(ctx context.Context, p Protocol) (*sessionConn, error) {
+	var (
+		transport  roundTripCloser
+		serverAddr string
+		err        error
+	)
+	switch p {
+	case ProtocolQUIC:
+		transport = c.newH3Transport()
+		serverAddr = c.opts.QUICServerAddr
+	case ProtocolH2:
+		transport, err = c.newH2Transport(ctx)
+		if err != nil {
+			return nil, err
+		}
+		serverAddr = c.opts.H2ServerAddr
+	default:
+		return nil, fmt.Errorf("private-dial: unsupported protocol %d", p)
+	}
+
+	h := &sessionConn{
+		proto:     p,
+		transport: transport,
+		stopCh:    make(chan struct{}),
+	}
+
 	controlURL := &url.URL{Scheme: "https", Host: serverAddr, Path: "/session"}
 	dialURL := &url.URL{Scheme: "https", Host: serverAddr, Path: "/dial"}
 
 	// io.Pipe for the request body — first frame is SessionReq, then
 	// the body is reused for client-→server ControlFrames (Ping/Pong).
 	bodyReader, bodyWriter := io.Pipe()
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, controlURL.String(), bodyReader)
+	h.controlReqBody = bodyWriter
+	reqCtx, reqCancel := context.WithCancel(context.Background())
+	h.controlCancel = reqCancel
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, controlURL.String(), bodyReader)
 	if err != nil {
+		_ = h.close()
 		return nil, fmt.Errorf("build /session request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+c.opts.AuthToken)
@@ -412,137 +460,204 @@ func (c *Client) openSessionWith(ctx context.Context, transport roundTripCloser,
 		}
 	}()
 
-	resp, err := transport.RoundTrip(req)
+	type roundTripResult struct {
+		resp *http.Response
+		err  error
+	}
+	roundTripCh := make(chan roundTripResult, 1)
+	go func() {
+		resp, err := transport.RoundTrip(req)
+		roundTripCh <- roundTripResult{resp: resp, err: err}
+	}()
+
+	var resp *http.Response
+	select {
+	case result := <-roundTripCh:
+		resp, err = result.resp, result.err
+	case <-ctx.Done():
+		_ = h.close()
+		return nil, fmt.Errorf("private-dial /session: %w", ctx.Err())
+	}
 	if err != nil {
-		_ = bodyWriter.Close()
-		transport.CloseIdleConnections()
+		_ = h.close()
 		return nil, fmt.Errorf("private-dial /session: %w", err)
 	}
 	if resp.StatusCode != http.StatusOK {
 		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
 		_ = resp.Body.Close()
-		_ = bodyWriter.Close()
-		transport.CloseIdleConnections()
-		return nil, fmt.Errorf("private-dial /session status %d: %s", resp.StatusCode, strings.TrimSpace(string(snippet)))
+		_ = h.close()
+		err := fmt.Errorf("private-dial /session status %d: %s", resp.StatusCode, strings.TrimSpace(string(snippet)))
+		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+			return nil, &authFatalError{status: resp.StatusCode, err: err}
+		}
+		return nil, err
 	}
 	respBody := newReadCloseByteReader(resp.Body)
 	resp.Body = respBody
 
 	ack := new(pbpd.SessionAck)
 	if err := protodelimUnmarshaler.UnmarshalFrom(respBody, ack); err != nil {
-		_ = resp.Body.Close()
-		_ = bodyWriter.Close()
-		transport.CloseIdleConnections()
+		_ = h.close()
 		return nil, fmt.Errorf("read SessionAck: %w", err)
 	}
 
-	sess := &Session{
-		serverID:        ack.GetServerId(),
-		pingInterval:    ack.GetPingInterval().AsDuration(),
-		transport:       transport,
-		dialURL:         dialURL,
-		authToken:       c.opts.AuthToken,
-		sessionReq:      &pbpd.SessionReq{ClientVersion: c.opts.ClientVersion, Metadata: c.opts.Metadata},
-		controlRespBody: respBody,
-		controlReqBody:  bodyWriter,
-		sendCh:          make(chan *pbpd.ControlFrame),
-		sendDone:        make(chan struct{}),
-		pings:           map[uint64]time.Time{},
-		drainCh:         make(chan struct{}),
-		serverErrCh:     make(chan error, 1),
-		stopCh:          make(chan struct{}),
-	}
-	// /session has acked, so we already received a server response. Any
-	// subsequent /dial on this session can drop the embedded SessionReq.
-	sess.responseReceived.Store(true)
-	go sess.controlSender()
-	go sess.readControl()
-	if sess.pingInterval > 0 {
-		go sess.pingLoop()
-	}
+	h.serverID = ack.GetServerId()
+	h.pingInterval = ack.GetPingInterval().AsDuration()
+	h.dialURL = dialURL
+	h.authToken = c.opts.AuthToken
+	h.controlRespBody = respBody
+	h.sendCh = make(chan *pbpd.ControlFrame)
+	h.sendDone = make(chan struct{})
+	h.pings = map[uint64]time.Time{}
+	h.drainCh = make(chan struct{})
+	h.serverErrCh = make(chan error, 1)
 
-	return sess, nil
+	go h.controlSender()
+	go h.readControl()
+	if h.pingInterval > 0 {
+		go h.pingLoop()
+	}
+	return h, nil
 }
 
-// Session represents an authenticated private-dial session. It multiplexes
-// Dial calls over a single HTTP/2 connection.
+// tlsConfigFor clones the configured TLS settings and pins them for the
+// given server address and ALPN protocol.
+func (c *Client) tlsConfigFor(serverAddr string, nextProtos ...string) *tls.Config {
+	tlsCfg := &tls.Config{}
+	if c.opts.TLSConfig != nil {
+		tlsCfg = c.opts.TLSConfig.Clone()
+	}
+	tlsCfg.ServerName = c.serverNameFor(serverAddr)
+	tlsCfg.NextProtos = nextProtos
+	if tlsCfg.MinVersion == 0 {
+		tlsCfg.MinVersion = tls.VersionTLS13
+	}
+	return tlsCfg
+}
+
+// newH2Transport builds an owned HTTP/2 ClientConn for one private-dial
+// control stream and its /dial streams. This avoids http2.Transport pooling
+// across logical sessions.
+func (c *Client) newH2Transport(ctx context.Context) (roundTripCloser, error) {
+	tlsConn, err := (&tls.Dialer{Config: c.tlsConfigFor(c.opts.H2ServerAddr, "h2")}).
+		DialContext(ctx, "tcp", c.opts.H2ServerAddr)
+	if err != nil {
+		return nil, fmt.Errorf("private-dial: tls dial: %w", err)
+	}
+	transport := &http2.Transport{
+		ReadIdleTimeout: 30 * time.Second,
+		PingTimeout:     15 * time.Second,
+	}
+	cc, err := transport.NewClientConn(tlsConn)
+	if err != nil {
+		_ = tlsConn.Close()
+		return nil, fmt.Errorf("private-dial: h2 client conn: %w", err)
+	}
+	return &h2ClientConnTransport{cc: cc}, nil
+}
+
+// newH3Transport builds the HTTP/3 (QUIC) transport. KeepAlivePeriod is the
+// QUIC analogue of the h2 keepalive PINGs: it keeps the single multiplexing
+// connection alive and surfaces a dead peer to stuck stream writers.
+func (c *Client) newH3Transport() roundTripCloser {
+	return &http3.Transport{
+		TLSClientConfig: c.tlsConfigFor(c.opts.QUICServerAddr, "h3"),
+		QUICConfig: &quic.Config{
+			KeepAlivePeriod: 30 * time.Second,
+		},
+	}
+}
+
+// authFatalError marks /session rejections that should not be retried.
+type authFatalError struct {
+	status int
+	err    error
+}
+
+func (e *authFatalError) Error() string { return e.err.Error() }
+func (e *authFatalError) Unwrap() error { return e.err }
+
+// Session represents an authenticated private-dial session. It reconnects on
+// server drain and control-stream failures while routing new Dial calls to the
+// freshest underlying transport.
 type Session struct {
-	serverID     string
-	pingInterval time.Duration
+	ctx    context.Context
+	cancel context.CancelFunc
 
 	// proto is the transport this session settled on (ProtocolQUIC or
 	// ProtocolH2). Set once at open time.
 	proto Protocol
 
-	transport roundTripCloser
-	dialURL   *url.URL
-	authToken string
+	// openFn opens replacement per-transport connections.
+	openFn func(context.Context) (*sessionConn, error)
 
-	// sessionReq is embedded in DialReq.session_req on /dial requests
-	// until responseReceived is true, so that a /dial opened in parallel
-	// with /session can self-authenticate server-side without waiting
-	// for SessionAck.
-	sessionReq       *pbpd.SessionReq
-	responseReceived atomic.Bool
+	clock sessionClock
 
-	controlRespBody *readCloseByteReader
-	controlReqBody  *io.PipeWriter
+	drainGroup sync.WaitGroup
 
-	// sendCh hands ControlFrames to the controlSender goroutine, which
-	// owns all writes to controlReqBody. Producers select on ctx/stopCh/
-	// sendDone alongside the send so a stalled wire never pins them.
-	sendCh   chan *pbpd.ControlFrame
-	sendDone chan struct{}
+	mu       sync.Mutex
+	current  *sessionConn
+	fatalErr error
+	// ready is closed every time current is replaced or fatalErr is set.
+	ready chan struct{}
 
-	// pings tracks outstanding client-→server pings keyed by their
-	// random 8-byte token, used to compute client-side RTT on Pong.
-	pingsMu sync.Mutex
-	pings   map[uint64]time.Time
+	dialWait time.Duration
 
 	drainOnce   sync.Once
 	drainCh     chan struct{}
 	serverErrCh chan error
 
-	// stopCh is closed by Close to halt the pingLoop and controlSender
-	// goroutines.
-	stopCh chan struct{}
-
-	// LastRTT is the most recent client-side ping round-trip time. Read
-	// it via LastRTT(); reset to zero before any successful pong arrives.
-	rttMu   sync.Mutex
-	lastRTT time.Duration
-
 	closeOnce sync.Once
-	closeErr  error
 }
 
-// ServerID returns the opaque identifier the server emitted in SessionAck.
-// Useful for log correlation across reconnects.
-func (s *Session) ServerID() string { return s.serverID }
+const defaultDialWait = 5 * time.Second
+
+// ServerID returns the opaque identifier the server emitted in the most recent
+// SessionAck, or the empty string if no conn is currently established.
+func (s *Session) ServerID() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.current == nil {
+		return ""
+	}
+	return s.current.serverID
+}
 
 // Protocol returns the transport this session settled on — ProtocolQUIC
 // (HTTP/3) or ProtocolH2 (HTTP/2).
 func (s *Session) Protocol() Protocol { return s.proto }
 
-// PingInterval is the cadence at which the server expects to send and
-// receive Ping frames on the control stream.
-func (s *Session) PingInterval() time.Duration { return s.pingInterval }
-
-// LastRTT returns the most recent round-trip time measured by the
-// client-side ping loop. Zero before the first pong arrives.
-func (s *Session) LastRTT() time.Duration {
-	s.rttMu.Lock()
-	defer s.rttMu.Unlock()
-	return s.lastRTT
+// PingInterval is the cadence at which the server expects to send and receive
+// Ping frames on the current control stream. Zero if no conn is established.
+func (s *Session) PingInterval() time.Duration {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.current == nil {
+		return 0
+	}
+	return s.current.pingInterval
 }
 
-// DrainCh is closed when the server sends a PleaseDrain control frame. Callers
-// should stop issuing new Dial calls once this fires.
+// LastRTT returns the most recent round-trip time measured by the client-side
+// ping loop on the current conn. Zero before the first pong arrives, and reset
+// to zero across reconnects.
+func (s *Session) LastRTT() time.Duration {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.current == nil {
+		return 0
+	}
+	return s.current.LastRTT()
+}
+
+// DrainCh is closed when any underlying connection receives PleaseDrain. The
+// Session will reconnect automatically; this method remains for compatibility
+// with callers that want to observe drain events.
 func (s *Session) DrainCh() <-chan struct{} { return s.drainCh }
 
-// ServerErrCh delivers, at most once, an error from the control stream (I/O
-// failure, explicit SessionError frame, or clean EOF as io.EOF). After a
-// value is delivered the session is effectively dead.
+// ServerErrCh delivers fatal logical-session errors, such as non-retryable auth
+// failures during reconnect. Transient control-stream failures are consumed by
+// the reconnect supervisor.
 func (s *Session) ServerErrCh() <-chan error { return s.serverErrCh }
 
 // DialContext opens a new stream targeting addr (of the form 'host:port').
@@ -581,25 +696,373 @@ func (s *Session) DialContext(ctx context.Context, network string, addr string) 
 
 	// we validated 'addr' is well formed, so we can just return it up to callers
 	// and save having to format in the port each time.
-	rAddr := dialAddr{addr: addr, host: host}
+	return s.dial(ctx, dialAddr{
+		addr: addr,
+		host: host,
+		port: int(port),
+	})
+}
 
+func (s *Session) dial(ctx context.Context, addr dialAddr) (net.Conn, error) {
+	timer := s.sessionClock().NewTimer(s.dialWaitTimeout())
+	defer timer.Stop()
+
+	dialErrFor := func(err error) error {
+		if ctx.Err() == nil && errors.Is(err, context.DeadlineExceeded) {
+			return &net.OpError{
+				Op:   "dial",
+				Net:  addr.Network(),
+				Addr: addr,
+				Err:  &os.SyscallError{Syscall: "connect", Err: syscall.ECONNREFUSED},
+			}
+		}
+		return &net.OpError{Op: "dial", Net: addr.Network(), Addr: addr, Err: err}
+	}
+
+	for {
+		select {
+		case <-timer.C():
+			return nil, dialErrFor(context.DeadlineExceeded)
+		default:
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, dialErrFor(err)
+		}
+		cur, err := s.waitForCurrent(ctx, timer.C())
+		if err != nil {
+			return nil, dialErrFor(err)
+		}
+		conn, dialErr := cur.dial(ctx, addr)
+		if dialErr == nil {
+			return conn, nil
+		}
+		if errors.Is(dialErr, context.Canceled) || errors.Is(dialErr, context.DeadlineExceeded) {
+			return nil, dialErr
+		}
+		var stale *staleConnError
+		if !errors.As(dialErr, &stale) {
+			return nil, dialErr
+		}
+	}
+}
+
+func (s *Session) waitForCurrent(ctx context.Context, budget <-chan time.Time) (*sessionConn, error) {
+	for {
+		if err := s.ctx.Err(); err != nil {
+			return nil, errors.New("private-dial: session closed")
+		}
+		cur, ready, fatal := s.snapshot()
+		if fatal != nil {
+			return nil, fatal
+		}
+		if cur != nil && cur.acceptsStreams() {
+			return cur, nil
+		}
+		select {
+		case <-ready:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-budget:
+			return nil, context.DeadlineExceeded
+		case <-s.ctx.Done():
+			return nil, errors.New("private-dial: session closed")
+		}
+	}
+}
+
+type staleConnError struct {
+	addr    dialAddr
+	wrapped error
+}
+
+func (e *staleConnError) Error() string {
+	if e.wrapped != nil {
+		return fmt.Sprintf("private-dial: stale conn: %s", e.wrapped)
+	}
+	return "private-dial: stale conn"
+}
+
+func (e *staleConnError) Unwrap() error { return e.wrapped }
+
+func newStaleConnError(addr dialAddr) *staleConnError {
+	return &staleConnError{addr: addr}
+}
+
+func (s *Session) dialWaitTimeout() time.Duration {
+	if s.dialWait > 0 {
+		return s.dialWait
+	}
+	return defaultDialWait
+}
+
+func (s *Session) snapshot() (*sessionConn, <-chan struct{}, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.current, s.ready, s.fatalErr
+}
+
+func (s *Session) supervise() {
+	for {
+		s.mu.Lock()
+		cur := s.current
+		s.mu.Unlock()
+		if cur == nil {
+			next, err := s.reconnect()
+			if err != nil {
+				return
+			}
+			s.swapCurrent(next)
+			continue
+		}
+		select {
+		case <-s.ctx.Done():
+			return
+		case <-cur.drainCh:
+			s.parkDraining(cur, cur.drainGrace)
+		case <-cur.serverErrCh:
+			select {
+			case <-cur.drainCh:
+				s.parkDraining(cur, cur.drainGrace)
+			default:
+				s.removeCurrent(cur)
+			}
+		}
+	}
+}
+
+func (s *Session) reconnect() (*sessionConn, error) {
+	boff := newReconnectBackoff(reconnectBackoffMinDelay, reconnectBackoffMaxDelay, s.sessionClock())
+	for {
+		if err := s.ctx.Err(); err != nil {
+			return nil, err
+		}
+		attemptCtx, cancel := context.WithTimeout(s.ctx, dialTimeout)
+		h, err := s.openFn(attemptCtx)
+		cancel()
+		if err == nil {
+			if cerr := s.ctx.Err(); cerr != nil {
+				_ = h.close()
+				return nil, cerr
+			}
+			return h, nil
+		}
+		var fatal *authFatalError
+		if errors.As(err, &fatal) {
+			s.setFatal(err)
+			return nil, err
+		}
+		if err := boff.Wait(s.ctx); err != nil {
+			return nil, err
+		}
+	}
+}
+
+const reconnectBackoffMinDelay = 8 * time.Millisecond
+const reconnectBackoffMaxDelay = 32768 * time.Millisecond
+
+type reconnectBackoff struct {
+	min   time.Duration
+	max   time.Duration
+	next  time.Duration
+	clock sessionClock
+}
+
+func newReconnectBackoff(minDelay, maxDelay time.Duration, clock sessionClock) *reconnectBackoff {
+	return &reconnectBackoff{min: minDelay, max: maxDelay, next: minDelay, clock: clock}
+}
+
+func (b *reconnectBackoff) Wait(ctx context.Context) error {
+	delay := b.next
+	if b.next < b.max {
+		jitter := 0.25 * ((2 * mathrand.Float64()) - 1)
+		next := time.Duration(float64(b.next) * (1.5 + jitter))
+		if next > b.max {
+			next = b.max
+		}
+		b.next = next
+	}
+
+	timer := b.clock.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-timer.C():
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (s *Session) sessionClock() sessionClock {
+	if s.clock != nil {
+		return s.clock
+	}
+	return realClock{}
+}
+
+func (s *Session) swapCurrent(h *sessionConn) {
+	s.mu.Lock()
+	if s.ctx.Err() != nil {
+		s.mu.Unlock()
+		_ = h.close()
+		return
+	}
+	s.current = h
+	s.signalReadyLocked()
+	s.mu.Unlock()
+}
+
+func (s *Session) parkDraining(old *sessionConn, grace time.Duration) {
+	s.drainOnce.Do(func() { close(s.drainCh) })
+
+	closeNow := false
+	s.mu.Lock()
+	if s.ctx.Err() != nil {
+		closeNow = true
+	} else {
+		if s.current == old {
+			s.current = nil
+		}
+		s.signalReadyLocked()
+
+		if grace <= 0 {
+			closeNow = true
+		} else {
+			clk := s.sessionClock()
+			s.drainGroup.Add(1)
+			go func() {
+				defer s.drainGroup.Done()
+				timer := clk.NewTimer(grace)
+				defer timer.Stop()
+				select {
+				case <-timer.C():
+				case <-s.ctx.Done():
+				}
+				_ = old.close()
+			}()
+		}
+	}
+	s.mu.Unlock()
+	if closeNow {
+		_ = old.close()
+	}
+}
+
+func (s *Session) removeCurrent(cur *sessionConn) {
+	s.mu.Lock()
+	if s.current == cur {
+		s.current = nil
+		s.signalReadyLocked()
+	}
+	s.mu.Unlock()
+	_ = cur.close()
+}
+
+func (s *Session) setFatal(err error) {
+	s.mu.Lock()
+	if s.fatalErr == nil {
+		s.fatalErr = err
+		select {
+		case s.serverErrCh <- err:
+		default:
+		}
+	}
+	s.signalReadyLocked()
+	s.mu.Unlock()
+}
+
+func (s *Session) signalReadyLocked() {
+	close(s.ready)
+	s.ready = make(chan struct{})
+}
+
+// Close tears down the supervisor, the active conn, and any conns still in
+// their drain grace window. In-flight Dial streams will see read/write errors.
+func (s *Session) Close() error {
+	s.closeOnce.Do(func() {
+		s.cancel()
+		s.mu.Lock()
+		cur := s.current
+		s.current = nil
+		s.signalReadyLocked()
+		s.mu.Unlock()
+		if cur != nil {
+			_ = cur.close()
+		}
+		s.drainGroup.Wait()
+	})
+	return nil
+}
+
+type sessionConn struct {
+	serverID     string
+	pingInterval time.Duration
+	proto        Protocol
+
+	transport roundTripCloser
+
+	lifeMu      sync.Mutex
+	lifeClosed  bool
+	lifeDrained bool
+
+	dialURL   *url.URL
+	authToken string
+
+	controlRespBody *readCloseByteReader
+	controlReqBody  *io.PipeWriter
+	controlCancel   context.CancelFunc
+
+	sendCh   chan *pbpd.ControlFrame
+	sendDone chan struct{}
+
+	pingsMu sync.Mutex
+	pings   map[uint64]time.Time
+
+	drainOnce  sync.Once
+	drainCh    chan struct{}
+	drainGrace time.Duration
+
+	serverErrCh chan error
+
+	stopCh chan struct{}
+
+	rttMu   sync.Mutex
+	lastRTT time.Duration
+
+	closeOnce sync.Once
+}
+
+func (h *sessionConn) LastRTT() time.Duration {
+	h.rttMu.Lock()
+	defer h.rttMu.Unlock()
+	return h.lastRTT
+}
+
+func (h *sessionConn) dial(ctx context.Context, addr dialAddr) (net.Conn, error) {
 	reqReader, reqWriter := io.Pipe()
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.dialURL.String(), reqReader)
+	reqCtx, reqCancel := context.WithCancel(context.Background())
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, h.dialURL.String(), reqReader)
 	if err != nil {
 		_ = reqWriter.Close()
-		return nil, &net.OpError{Op: "dial", Net: network, Addr: rAddr, Err: fmt.Errorf("build /dial request: %w", err)}
+		reqCancel()
+		return nil, &net.OpError{Op: "dial", Net: addr.Network(), Addr: addr, Err: fmt.Errorf("build /dial request: %w", err)}
 	}
-	req.Header.Set("Authorization", "Bearer "+s.authToken)
+	req.Header.Set("Authorization", "Bearer "+h.authToken)
 	req.Header.Set("Content-Type", "application/octet-stream")
 
 	dreq := &pbpd.DialReq{
-		Host: host,
-		Port: int64(port),
+		Host: addr.host,
+		Port: int64(addr.port),
 	}
-	// Until we've seen any response from the server, embed SessionReq so
-	// that /dial can authenticate on its own when raced ahead of /session.
-	if !s.responseReceived.Load() {
-		dreq.SessionReq = s.sessionReq
+
+	if !h.acceptsStreams() {
+		_ = reqWriter.Close()
+		reqCancel()
+		return nil, newStaleConnError(addr)
+	}
+	if reserver, ok := h.transport.(requestReserver); ok && !reserver.ReserveNewRequest() {
+		_ = reqWriter.Close()
+		reqCancel()
+		return nil, newStaleConnError(addr)
 	}
 
 	// RoundTrip blocks on the response, and the server won't respond
@@ -612,24 +1075,48 @@ func (s *Session) DialContext(ctx context.Context, network string, addr string) 
 		}
 	}()
 
-	resp, err := s.transport.RoundTrip(req)
+	type roundTripResult struct {
+		resp *http.Response
+		err  error
+	}
+	roundTripCh := make(chan roundTripResult, 1)
+	go func() {
+		resp, err := h.transport.RoundTrip(req)
+		roundTripCh <- roundTripResult{resp: resp, err: err}
+	}()
+
+	var resp *http.Response
+	select {
+	case result := <-roundTripCh:
+		resp, err = result.resp, result.err
+	case <-ctx.Done():
+		_ = reqWriter.Close()
+		reqCancel()
+		return nil, &net.OpError{Op: "dial", Net: addr.Network(), Addr: addr, Err: ctx.Err()}
+	}
 	if err != nil {
 		_ = reqWriter.Close()
-		return nil, &net.OpError{Op: "dial", Net: network, Addr: rAddr, Err: err}
+		reqCancel()
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, &net.OpError{Op: "dial", Net: addr.Network(), Addr: addr, Err: err}
+		}
+		se := newStaleConnError(addr)
+		se.wrapped = err
+		return nil, se
 	}
-	// Any successful response from the server means our auth went through.
-	s.responseReceived.Store(true)
 	if resp.StatusCode != http.StatusOK {
 		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
 		_ = resp.Body.Close()
 		_ = reqWriter.Close()
-		return nil, dialResponseError(resp, rAddr, string(snippet))
+		reqCancel()
+		return nil, dialResponseError(resp, addr, string(snippet))
 	}
 
 	return &dialConn{
-		remoteAddr: rAddr,
+		remoteAddr: addr,
 		reqBody:    reqWriter,
 		respBody:   resp.Body,
+		reqCancel:  reqCancel,
 	}, nil
 }
 
@@ -712,18 +1199,50 @@ func (e *ServerError) Error() string {
 // ServerError's status code, so errors.Is / errors.As walks down to it.
 func (e *ServerError) Unwrap() error { return e.wrapped }
 
-// Close tears down the control stream and the underlying HTTP/2 connection.
-// Any in-flight Dial streams will see read/write errors.
-func (s *Session) Close() error {
-	s.closeOnce.Do(func() {
-		close(s.stopCh)
-		_ = s.controlReqBody.Close()
-		if s.controlRespBody != nil {
-			_ = s.controlRespBody.Close()
-		}
-		s.transport.CloseIdleConnections()
+func (h *sessionConn) markClosed() {
+	h.lifeMu.Lock()
+	defer h.lifeMu.Unlock()
+	h.lifeClosed = true
+}
+
+func (h *sessionConn) markDraining(grace time.Duration) {
+	h.drainOnce.Do(func() {
+		h.drainGrace = grace
+		h.lifeMu.Lock()
+		h.lifeDrained = true
+		h.lifeMu.Unlock()
+		close(h.drainCh)
 	})
-	return s.closeErr
+}
+
+func (h *sessionConn) acceptsStreams() bool {
+	h.lifeMu.Lock()
+	defer h.lifeMu.Unlock()
+	return !h.lifeClosed && !h.lifeDrained
+}
+
+func (h *sessionConn) close() error {
+	h.closeOnce.Do(func() {
+		h.markClosed()
+		close(h.stopCh)
+		if h.controlReqBody != nil {
+			_ = h.controlReqBody.Close()
+		}
+		if h.controlRespBody != nil {
+			_ = h.controlRespBody.Close()
+		}
+		if h.controlCancel != nil {
+			h.controlCancel()
+		}
+		if h.transport != nil {
+			if closer, ok := h.transport.(closeTransport); ok {
+				_ = closer.Close()
+			} else {
+				h.transport.CloseIdleConnections()
+			}
+		}
+	})
+	return nil
 }
 
 // errSessionClosed is returned by sendControlFrame when the session has
@@ -735,15 +1254,15 @@ var errSessionClosed = errors.New("private-dial: session closed")
 // pipe write indefinitely — see controlSender) doesn't pin the
 // caller. The actual proto write happens asynchronously; a nil
 // return means the frame was enqueued, not that bytes hit the wire.
-func (s *Session) sendControlFrame(ctx context.Context, frame *pbpd.ControlFrame) error {
+func (h *sessionConn) sendControlFrame(ctx context.Context, frame *pbpd.ControlFrame) error {
 	select {
-	case s.sendCh <- frame:
+	case h.sendCh <- frame:
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()
-	case <-s.stopCh:
+	case <-h.stopCh:
 		return errSessionClosed
-	case <-s.sendDone:
+	case <-h.sendDone:
 		return errSessionClosed
 	}
 }
@@ -754,16 +1273,16 @@ func (s *Session) sendControlFrame(ctx context.Context, frame *pbpd.ControlFrame
 // when the peer stops reading. A terminal write error is forwarded
 // to serverErrCh and the goroutine exits, closing sendDone so
 // queued senders unblock.
-func (s *Session) controlSender() {
-	defer close(s.sendDone)
+func (h *sessionConn) controlSender() {
+	defer close(h.sendDone)
 	for {
 		select {
-		case <-s.stopCh:
+		case <-h.stopCh:
 			return
-		case frame := <-s.sendCh:
-			if _, err := protodelim.MarshalTo(s.controlReqBody, frame); err != nil {
+		case frame := <-h.sendCh:
+			if _, err := protodelim.MarshalTo(h.controlReqBody, frame); err != nil {
 				select {
-				case s.serverErrCh <- err:
+				case h.serverErrCh <- err:
 				default:
 				}
 				return
@@ -778,17 +1297,17 @@ func (s *Session) controlSender() {
 // Each tick uses a per-send timeout of pingInterval so a stuck sender
 // can't pin successive ticks; transient timeouts just skip a ping and
 // let the next tick try again. Terminal errSessionClosed exits the loop.
-func (s *Session) pingLoop() {
-	tick := time.NewTicker(s.pingInterval)
+func (h *sessionConn) pingLoop() {
+	tick := time.NewTicker(h.pingInterval)
 	defer tick.Stop()
 	for {
 		select {
-		case <-s.stopCh:
+		case <-h.stopCh:
 			return
 		case <-tick.C:
-			token := s.recordPingSent(time.Now())
-			ctx, cancel := context.WithTimeout(context.Background(), s.pingInterval)
-			err := s.sendControlFrame(ctx, &pbpd.ControlFrame{
+			token := h.recordPingSent(time.Now())
+			ctx, cancel := context.WithTimeout(context.Background(), h.pingInterval)
+			err := h.sendControlFrame(ctx, &pbpd.ControlFrame{
 				Frame: &pbpd.ControlFrame_Ping{Ping: &pbpd.Ping{Token: token}},
 			})
 			cancel()
@@ -799,24 +1318,24 @@ func (s *Session) pingLoop() {
 	}
 }
 
-func (s *Session) recordPingSent(now time.Time) uint64 {
+func (h *sessionConn) recordPingSent(now time.Time) uint64 {
 	var buf [8]byte
-	_, _ = rand.Read(buf[:])
+	_, _ = cryptorand.Read(buf[:])
 	token := binary.LittleEndian.Uint64(buf[:])
-	s.pingsMu.Lock()
-	s.pings[token] = now
-	s.pingsMu.Unlock()
+	h.pingsMu.Lock()
+	h.pings[token] = now
+	h.pingsMu.Unlock()
 	return token
 }
 
-func (s *Session) completePing(token uint64, now time.Time) (time.Duration, bool) {
-	s.pingsMu.Lock()
-	defer s.pingsMu.Unlock()
-	sent, ok := s.pings[token]
+func (h *sessionConn) completePing(token uint64, now time.Time) (time.Duration, bool) {
+	h.pingsMu.Lock()
+	defer h.pingsMu.Unlock()
+	sent, ok := h.pings[token]
 	if !ok {
 		return 0, false
 	}
-	delete(s.pings, token)
+	delete(h.pings, token)
 	return now.Sub(sent), true
 }
 
@@ -824,56 +1343,57 @@ func (s *Session) completePing(token uint64, now time.Time) (time.Duration, bool
 // It closes drainCh on PleaseDrain, echoes Pong on inbound Ping (so the
 // server can measure its RTT to us), records client-side RTT on Pong,
 // and forwards terminal errors to serverErrCh.
-func (s *Session) readControl() {
+func (h *sessionConn) readControl() {
 	defer func() {
 		select {
-		case s.serverErrCh <- io.EOF:
+		case h.serverErrCh <- io.EOF:
 		default:
 		}
 	}()
 	for {
 		frame := new(pbpd.ControlFrame)
-		if err := protodelimUnmarshaler.UnmarshalFrom(s.controlRespBody, frame); err != nil {
+		if err := protodelimUnmarshaler.UnmarshalFrom(h.controlRespBody, frame); err != nil {
 			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 				return
 			}
 			select {
-			case s.serverErrCh <- err:
+			case h.serverErrCh <- err:
 			default:
 			}
 			return
 		}
 		switch f := frame.Frame.(type) {
 		case *pbpd.ControlFrame_PleaseDrain:
-			s.drainOnce.Do(func() { close(s.drainCh) })
+			h.markDraining(time.Duration(f.PleaseDrain.GetGracePeriodSeconds()) * time.Second)
 		case *pbpd.ControlFrame_SessionError:
 			select {
-			case s.serverErrCh <- fmt.Errorf("server session error: %s", f.SessionError.GetMessage()):
+			case h.serverErrCh <- fmt.Errorf("server session error: %s", f.SessionError.GetMessage()):
 			default:
 			}
 			return
 		case *pbpd.ControlFrame_Ping:
-			_ = s.sendControlFrame(context.Background(), &pbpd.ControlFrame{
+			_ = h.sendControlFrame(context.Background(), &pbpd.ControlFrame{
 				Frame: &pbpd.ControlFrame_Pong{Pong: &pbpd.Pong{Token: f.Ping.GetToken()}},
 			})
 		case *pbpd.ControlFrame_Pong:
-			if rtt, ok := s.completePing(f.Pong.GetToken(), time.Now()); ok {
-				s.rttMu.Lock()
-				s.lastRTT = rtt
-				s.rttMu.Unlock()
+			if rtt, ok := h.completePing(f.Pong.GetToken(), time.Now()); ok {
+				h.rttMu.Lock()
+				h.lastRTT = rtt
+				h.rttMu.Unlock()
 			}
 		}
 	}
 }
 
 // dialConn is the net.Conn returned from Session.DialContext. Read pulls
-// from the HTTP/2 response body; Write pushes into the HTTP/2 request body.
-// Close terminates both sides. Dial-level failures never reach a dialConn —
-// they're returned from DialContext directly as *net.OpError. EOF on Read
-// surfaces normally as io.EOF.
+// from the response body; Write pushes into the request body. Close terminates
+// both sides. Dial-level failures never reach a dialConn — they're returned
+// from DialContext directly as *net.OpError. EOF on Read surfaces normally as
+// io.EOF.
 type dialConn struct {
-	reqBody  *io.PipeWriter
-	respBody io.ReadCloser
+	reqBody   *io.PipeWriter
+	respBody  io.ReadCloser
+	reqCancel context.CancelFunc
 
 	remoteAddr dialAddr
 
@@ -893,6 +1413,9 @@ func (c *dialConn) Close() error {
 	c.closeOnce.Do(func() {
 		_ = c.reqBody.Close()
 		_ = c.respBody.Close()
+		if c.reqCancel != nil {
+			c.reqCancel()
+		}
 	})
 	return nil
 }
@@ -909,6 +1432,7 @@ func (c *dialConn) SetWriteDeadline(_ time.Time) error { return nil }
 type dialAddr struct {
 	addr string // host:port
 	host string
+	port int
 }
 
 func (a dialAddr) Network() string { return "tcp" }

--- a/privatedial/client_integration_test.go
+++ b/privatedial/client_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"fmt"
 	"io"
 	"math/big"
 	"net"
@@ -246,6 +247,152 @@ func TestDialEcho(t *testing.T) {
 	}
 }
 
+func TestDrainReconnect(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		proto Protocol
+	}{
+		{"h2", ProtocolH2},
+		{"quic", ProtocolQUIC},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resetSticky()
+			cert := genTLSCert(t)
+			var sessionN atomic.Int32
+			firstDrainCh := make(chan struct{})
+
+			mux := http.NewServeMux()
+			mux.HandleFunc("/session", func(w http.ResponseWriter, r *http.Request) {
+				n := sessionN.Add(1)
+				var req pbpd.SessionReq
+				if err := protodelimUnmarshaler.UnmarshalFrom(bufio.NewReader(r.Body), &req); err != nil {
+					http.Error(w, "bad SessionReq", http.StatusBadRequest)
+					return
+				}
+				if _, err := protodelim.MarshalTo(w, &pbpd.SessionAck{ServerId: fmt.Sprintf("srv-%d", n)}); err != nil {
+					return
+				}
+				flush(w)
+				if n == 1 {
+					select {
+					case <-firstDrainCh:
+					case <-r.Context().Done():
+						return
+					}
+					_, _ = protodelim.MarshalTo(w, &pbpd.ControlFrame{
+						Frame: &pbpd.ControlFrame_PleaseDrain{
+							PleaseDrain: &pbpd.PleaseDrain{GracePeriodSeconds: 1},
+						},
+					})
+					flush(w)
+				}
+				<-r.Context().Done()
+			})
+			mux.HandleFunc("/dial", echoDialHandler)
+
+			sess := mustOpenSession(t, clientOptsForProtocol(t, tc.proto, cert, mux))
+			defer sess.Close()
+
+			if got := sess.Protocol(); got != tc.proto {
+				t.Fatalf("Protocol = %v, want %v", got, tc.proto)
+			}
+			if got := sess.ServerID(); got != "srv-1" {
+				t.Fatalf("initial ServerID = %q, want srv-1", got)
+			}
+			conn1 := mustDial(t, sess, "first.private:80")
+			assertEcho(t, conn1, "before-drain")
+			_ = conn1.Close()
+
+			close(firstDrainCh)
+			waitFor(t, 3*time.Second, func() bool { return sess.ServerID() == "srv-2" })
+
+			conn2 := mustDial(t, sess, "second.private:443")
+			if got := conn2.RemoteAddr().Network(); got != "tcp" {
+				t.Fatalf("RemoteAddr network = %q, want tcp", got)
+			}
+			if got := conn2.RemoteAddr().String(); got != "second.private:443" {
+				t.Fatalf("RemoteAddr string = %q, want second.private:443", got)
+			}
+			assertEcho(t, conn2, "after-drain")
+			_ = conn2.Close()
+		})
+	}
+}
+
+func TestAbruptControlStreamReconnect(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		proto Protocol
+	}{
+		{"h2", ProtocolH2},
+		{"quic", ProtocolQUIC},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resetSticky()
+			cert := genTLSCert(t)
+			var sessionN atomic.Int32
+			dropFirst := make(chan struct{})
+
+			mux := http.NewServeMux()
+			mux.HandleFunc("/session", func(w http.ResponseWriter, r *http.Request) {
+				n := sessionN.Add(1)
+				var req pbpd.SessionReq
+				if err := protodelimUnmarshaler.UnmarshalFrom(bufio.NewReader(r.Body), &req); err != nil {
+					http.Error(w, "bad SessionReq", http.StatusBadRequest)
+					return
+				}
+				if _, err := protodelim.MarshalTo(w, &pbpd.SessionAck{ServerId: fmt.Sprintf("srv-%d", n)}); err != nil {
+					return
+				}
+				flush(w)
+				if n == 1 {
+					select {
+					case <-dropFirst:
+					case <-r.Context().Done():
+					}
+					return
+				}
+				<-r.Context().Done()
+			})
+			mux.HandleFunc("/dial", echoDialHandler)
+
+			sess := mustOpenSession(t, clientOptsForProtocol(t, tc.proto, cert, mux))
+			defer sess.Close()
+
+			if got := sess.Protocol(); got != tc.proto {
+				t.Fatalf("Protocol = %v, want %v", got, tc.proto)
+			}
+			if got := sess.ServerID(); got != "srv-1" {
+				t.Fatalf("initial ServerID = %q, want srv-1", got)
+			}
+			close(dropFirst)
+			waitFor(t, 3*time.Second, func() bool { return sess.ServerID() == "srv-2" })
+
+			conn := mustDial(t, sess, "after-drop.private:80")
+			assertEcho(t, conn, "after-drop")
+			_ = conn.Close()
+		})
+	}
+}
+
+func clientOptsForProtocol(t *testing.T, proto Protocol, cert tls.Certificate, h http.Handler) ClientOpts {
+	t.Helper()
+	opts := ClientOpts{
+		AuthToken:     "test-token",
+		ForceProtocol: proto,
+		TLSConfig:     &tls.Config{InsecureSkipVerify: true},
+	}
+	switch proto {
+	case ProtocolH2:
+		opts.H2ServerAddr = startH2Server(t, cert, h)
+	case ProtocolQUIC:
+		opts.QUICServerAddr = startH3Server(t, cert, h)
+	default:
+		t.Fatalf("unsupported protocol %v", proto)
+	}
+	return opts
+}
+
 // mustOpenSession opens a session with the given opts, failing the test on
 // error.
 func mustOpenSession(t *testing.T, opts ClientOpts) *Session {
@@ -257,6 +404,43 @@ func mustOpenSession(t *testing.T, opts ClientOpts) *Session {
 		t.Fatalf("OpenSession: %v", err)
 	}
 	return sess
+}
+
+func mustDial(t *testing.T, sess *Session, addr string) net.Conn {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, err := sess.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		t.Fatalf("DialContext: %v", err)
+	}
+	return conn
+}
+
+func assertEcho(t *testing.T, conn net.Conn, msg string) {
+	t.Helper()
+	if _, err := io.WriteString(conn, msg); err != nil {
+		t.Fatalf("WriteString: %v", err)
+	}
+	buf := make([]byte, len(msg))
+	if _, err := io.ReadFull(conn, buf); err != nil {
+		t.Fatalf("ReadFull: %v", err)
+	}
+	if string(buf) != msg {
+		t.Fatalf("echo mismatch: got %q want %q", buf, msg)
+	}
+}
+
+func waitFor(t *testing.T, timeout time.Duration, fn func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if fn() {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("waitFor timed out after %s", timeout)
 }
 
 // privateDialHandler returns a handler that speaks the private-dial protocol:
@@ -300,6 +484,18 @@ func privateDialHandler(counter *atomic.Int64) http.Handler {
 	})
 
 	return mux
+}
+
+func echoDialHandler(w http.ResponseWriter, r *http.Request) {
+	br := bufio.NewReader(r.Body)
+	var dreq pbpd.DialReq
+	if err := protodelimUnmarshaler.UnmarshalFrom(br, &dreq); err != nil {
+		http.Error(w, "bad DialReq", http.StatusBadRequest)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	flush(w)
+	_, _ = io.Copy(flushWriter{w}, br)
 }
 
 func flush(w http.ResponseWriter) {

--- a/privatedial/client_test.go
+++ b/privatedial/client_test.go
@@ -1,0 +1,860 @@
+package privatedial
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	"google.golang.org/protobuf/encoding/protodelim"
+
+	pbpd "golang.ngrok.com/ngrok/privatedial/pb_private_dial"
+)
+
+func newFakeConn(id string) *sessionConn {
+	return &sessionConn{
+		serverID:    id,
+		proto:       ProtocolH2,
+		drainCh:     make(chan struct{}),
+		serverErrCh: make(chan error, 1),
+		stopCh:      make(chan struct{}),
+		sendDone:    make(chan struct{}),
+		dialURL:     &url.URL{Scheme: "https", Host: "fake.invalid", Path: "/dial"},
+	}
+}
+
+func sequentialOpener() func(context.Context) (*sessionConn, error) {
+	var n atomic.Int32
+	return func(context.Context) (*sessionConn, error) {
+		return newFakeConn(idFor(n.Add(1))), nil
+	}
+}
+
+func newTestSession(t *testing.T, openFn func(context.Context) (*sessionConn, error)) *Session {
+	t.Helper()
+	s, _ := newTestSessionWithClock(t, openFn)
+	return s
+}
+
+func newTestSessionWithClock(t *testing.T, openFn func(context.Context) (*sessionConn, error)) (*Session, *manualClock) {
+	t.Helper()
+	first, err := openFn(context.Background())
+	if err != nil {
+		t.Fatalf("initial openFn: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	clk := newManualClock(time.Now())
+	s := &Session{
+		ctx:         ctx,
+		cancel:      cancel,
+		proto:       ProtocolH2,
+		ready:       make(chan struct{}),
+		current:     first,
+		openFn:      openFn,
+		clock:       clk,
+		drainCh:     make(chan struct{}),
+		serverErrCh: make(chan error, 1),
+	}
+	go s.supervise()
+	t.Cleanup(func() { _ = s.Close() })
+	return s, clk
+}
+
+func TestReconnectBacksOffAfterTransientOpenError(t *testing.T) {
+	first := newFakeConn("conn-1")
+	second := newFakeConn("conn-2")
+	transient := errors.New("transient")
+
+	var calls atomic.Int32
+	openFn := func(context.Context) (*sessionConn, error) {
+		switch calls.Add(1) {
+		case 1:
+			return first, nil
+		case 2:
+			return nil, transient
+		default:
+			return second, nil
+		}
+	}
+	s, clk := newTestSessionWithClock(t, openFn)
+
+	first.serverErrCh <- errors.New("boom")
+
+	waitFor(t, time.Second, func() bool { return calls.Load() == 2 })
+	cur, _, _ := s.snapshot()
+	if cur != nil {
+		t.Fatalf("transient failure installed replacement: %v", cur.serverID)
+	}
+	waitFor(t, time.Second, clk.HasWaiters)
+	clk.Step(reconnectBackoffMinDelay)
+	waitFor(t, time.Second, func() bool { return s.ServerID() == "conn-2" })
+}
+
+func TestReconnectOnDrain(t *testing.T) {
+	s := newTestSession(t, sequentialOpener())
+	if got := s.ServerID(); got != "conn-1" {
+		t.Fatalf("ServerID = %q, want conn-1", got)
+	}
+
+	first := s.snapshotCurrentForTest()
+	first.markDraining(50 * time.Millisecond)
+
+	waitFor(t, time.Second, func() bool { return s.ServerID() == "conn-2" })
+}
+
+func TestDrainKeepsOldConnAliveForGrace(t *testing.T) {
+	s, clk := newTestSessionWithClock(t, sequentialOpener())
+
+	first := s.snapshotCurrentForTest()
+	first.markDraining(time.Hour)
+
+	waitFor(t, time.Second, func() bool { return s.ServerID() == "conn-2" })
+	waitFor(t, time.Second, clk.HasWaiters)
+	if isClosed(first.stopCh) {
+		t.Fatal("first conn closed before grace expired")
+	}
+	clk.Step(time.Hour)
+	waitFor(t, time.Second, func() bool { return isClosed(first.stopCh) })
+}
+
+func TestDrainParksOldConnImmediately(t *testing.T) {
+	first := newFakeConn("conn-1")
+	second := newFakeConn("conn-2")
+
+	gate := make(chan struct{})
+	var calls atomic.Int32
+	openFn := func(context.Context) (*sessionConn, error) {
+		i := calls.Add(1)
+		if i == 1 {
+			return first, nil
+		}
+		<-gate
+		return second, nil
+	}
+	s, clk := newTestSessionWithClock(t, openFn)
+
+	first.markDraining(time.Hour)
+
+	waitFor(t, time.Second, func() bool {
+		cur, _, _ := s.snapshot()
+		return cur == nil
+	})
+	waitFor(t, time.Second, clk.HasWaiters)
+	if isClosed(first.stopCh) {
+		t.Fatal("first conn closed before reconnect gate opened")
+	}
+
+	close(gate)
+	waitFor(t, time.Second, func() bool { return s.ServerID() == "conn-2" })
+	clk.Step(time.Hour)
+	waitFor(t, time.Second, func() bool { return isClosed(first.stopCh) })
+}
+
+func TestReconnectOnAbruptError(t *testing.T) {
+	s := newTestSession(t, sequentialOpener())
+	if got := s.ServerID(); got != "conn-1" {
+		t.Fatalf("ServerID = %q, want conn-1", got)
+	}
+
+	first := s.snapshotCurrentForTest()
+	first.serverErrCh <- errors.New("boom")
+
+	waitFor(t, time.Second, func() bool { return s.ServerID() == "conn-2" })
+	waitFor(t, time.Second, func() bool { return isClosed(first.stopCh) })
+}
+
+func TestAuthFatalStopsReconnect(t *testing.T) {
+	first := newFakeConn("conn-1")
+	var calls atomic.Int32
+	fatal := &authFatalError{status: http.StatusUnauthorized, err: errors.New("bad token")}
+	openFn := func(context.Context) (*sessionConn, error) {
+		i := calls.Add(1)
+		if i == 1 {
+			return first, nil
+		}
+		return nil, fatal
+	}
+	s := newTestSession(t, openFn)
+
+	first.serverErrCh <- errors.New("boom")
+
+	waitFor(t, time.Second, func() bool {
+		_, _, ferr := s.snapshot()
+		return ferr != nil
+	})
+
+	_, err := s.DialContext(context.Background(), "tcp", "x.private:80")
+	if err == nil {
+		t.Fatal("Dial succeeded, want fatal error")
+	}
+	var op *net.OpError
+	if !errors.As(err, &op) {
+		t.Fatalf("error %T does not wrap *net.OpError", err)
+	}
+	if !errors.Is(err, fatal) {
+		t.Fatalf("error = %v, want auth fatal", err)
+	}
+}
+
+func TestDialBlocksThenTimesOutWhenNoCurrent(t *testing.T) {
+	first := newFakeConn("conn-1")
+	transient := errors.New("transient")
+	var calls atomic.Int32
+	openFn := func(context.Context) (*sessionConn, error) {
+		i := calls.Add(1)
+		if i == 1 {
+			return first, nil
+		}
+		return nil, transient
+	}
+	s, clk := newTestSessionWithClock(t, openFn)
+	s.dialWait = 80 * time.Millisecond
+
+	first.serverErrCh <- errors.New("boom")
+	waitFor(t, time.Second, func() bool {
+		cur, _, _ := s.snapshot()
+		return cur == nil
+	})
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := s.DialContext(context.Background(), "tcp", "x.private:80")
+		errCh <- err
+	}()
+	waitFor(t, time.Second, func() bool { return clk.NumWaiters() >= 2 })
+	clk.Step(80 * time.Millisecond)
+
+	err := <-errCh
+	if err == nil {
+		t.Fatal("Dial succeeded, want timeout")
+	}
+	if !errors.Is(err, syscall.ECONNREFUSED) {
+		t.Fatalf("error = %v, want ECONNREFUSED", err)
+	}
+}
+
+func TestWaitForCurrentWakesOnReconnect(t *testing.T) {
+	first := newFakeConn("conn-1")
+	second := newFakeConn("conn-2")
+
+	gate := make(chan struct{})
+	var calls atomic.Int32
+	openFn := func(context.Context) (*sessionConn, error) {
+		i := calls.Add(1)
+		if i == 1 {
+			return first, nil
+		}
+		<-gate
+		return second, nil
+	}
+	s := newTestSession(t, openFn)
+	s.dialWait = 5 * time.Second
+
+	first.serverErrCh <- errors.New("boom")
+	waitFor(t, time.Second, func() bool {
+		cur, _, _ := s.snapshot()
+		return cur == nil
+	})
+
+	type result struct {
+		cur *sessionConn
+		err error
+	}
+	out := make(chan result, 1)
+	go func() {
+		cur, err := s.waitForCurrent(context.Background(), make(chan time.Time))
+		out <- result{cur: cur, err: err}
+	}()
+
+	close(gate)
+
+	select {
+	case r := <-out:
+		if r.err != nil {
+			t.Fatalf("waitForCurrent error: %v", r.err)
+		}
+		if r.cur != second {
+			t.Fatalf("waitForCurrent conn = %p, want %p", r.cur, second)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("waitForCurrent did not wake after reconnect")
+	}
+}
+
+func TestDrainWinsOverConcurrentServerErr(t *testing.T) {
+	s := newTestSession(t, sequentialOpener())
+	first := s.snapshotCurrentForTest()
+
+	first.markDraining(time.Second)
+	first.serverErrCh <- errors.New("boom")
+
+	waitFor(t, time.Second, func() bool { return s.ServerID() == "conn-2" })
+	if isClosed(first.stopCh) {
+		t.Fatal("first conn hard-closed instead of parked for grace")
+	}
+}
+
+func TestCloseDuringReconnectDiscardsLateConn(t *testing.T) {
+	first := newFakeConn("conn-1")
+	second := newFakeConn("conn-2")
+
+	release := make(chan struct{})
+	entered := make(chan struct{})
+	var calls atomic.Int32
+	openFn := func(context.Context) (*sessionConn, error) {
+		i := calls.Add(1)
+		if i == 1 {
+			return first, nil
+		}
+		close(entered)
+		<-release
+		return second, nil
+	}
+	s := newTestSession(t, openFn)
+
+	first.serverErrCh <- errors.New("boom")
+	waitForChan(t, entered, time.Second, "openFn entered")
+
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	close(release)
+	waitFor(t, time.Second, func() bool { return isClosed(second.stopCh) })
+
+	cur, _, _ := s.snapshot()
+	if cur != nil {
+		t.Fatalf("current resurrected after Close: %v", cur.serverID)
+	}
+}
+
+func TestDialSkipsDrainedCurrent(t *testing.T) {
+	first := newFakeConn("conn-1")
+	clk := newManualClock(time.Now())
+	openFn := func(context.Context) (*sessionConn, error) {
+		return first, nil
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &Session{
+		ctx:         ctx,
+		cancel:      cancel,
+		proto:       ProtocolH2,
+		ready:       make(chan struct{}),
+		current:     first,
+		openFn:      openFn,
+		clock:       clk,
+		dialWait:    200 * time.Millisecond,
+		drainCh:     make(chan struct{}),
+		serverErrCh: make(chan error, 1),
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	first.markDraining(time.Second)
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := s.DialContext(context.Background(), "tcp", "x.private:80")
+		errCh <- err
+	}()
+	waitFor(t, time.Second, clk.HasWaiters)
+	clk.Step(200 * time.Millisecond)
+
+	err := <-errCh
+	if err == nil {
+		t.Fatal("Dial succeeded on drained conn")
+	}
+	if !errors.Is(err, syscall.ECONNREFUSED) {
+		t.Fatalf("error = %v, want ECONNREFUSED", err)
+	}
+}
+
+func TestAcceptStreamSerializesWithDrain(t *testing.T) {
+	h := newFakeConn("conn-1")
+	if !h.acceptsStreams() {
+		t.Fatal("fresh conn must accept streams")
+	}
+
+	h.markDraining(0)
+	if h.acceptsStreams() {
+		t.Fatal("drained conn accepts streams")
+	}
+	if !isClosed(h.drainCh) {
+		t.Fatal("markDraining did not signal drainCh")
+	}
+}
+
+func TestAcceptStreamSerializesWithClose(t *testing.T) {
+	h := newFakeConn("conn-1")
+	_ = h.close()
+	if h.acceptsStreams() {
+		t.Fatal("closed conn accepts streams")
+	}
+}
+
+func TestCloseStopsGraceTimers(t *testing.T) {
+	s, clk := newTestSessionWithClock(t, sequentialOpener())
+	first := s.snapshotCurrentForTest()
+
+	first.markDraining(time.Hour)
+	waitFor(t, time.Second, func() bool { return s.ServerID() == "conn-2" })
+	waitFor(t, time.Second, clk.HasWaiters)
+
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if !isClosed(first.stopCh) {
+		t.Fatal("first draining conn not closed by Close")
+	}
+	if n := clk.NumWaiters(); n != 0 {
+		t.Fatalf("Close left %d grace timers", n)
+	}
+}
+
+func TestSessionConnDialRefusesAfterClose(t *testing.T) {
+	h := newFakeConn("conn-1")
+	_ = h.close()
+
+	_, err := h.dial(context.Background(), dialAddr{addr: "x.private:80", host: "x.private", port: 80})
+	if err == nil {
+		t.Fatal("dial succeeded after close")
+	}
+	var stale *staleConnError
+	if !errors.As(err, &stale) {
+		t.Fatalf("error %T does not wrap staleConnError", err)
+	}
+}
+
+func TestParkDrainingNoOpAfterClose(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &Session{
+		ctx:         ctx,
+		cancel:      cancel,
+		ready:       make(chan struct{}),
+		dialWait:    50 * time.Millisecond,
+		openFn:      func(context.Context) (*sessionConn, error) { return nil, errors.New("never") },
+		drainCh:     make(chan struct{}),
+		serverErrCh: make(chan error, 1),
+	}
+	cancel()
+
+	h := newFakeConn("conn-1")
+	s.parkDraining(h, time.Hour)
+
+	if !isClosed(h.stopCh) {
+		t.Fatal("parkDraining did not close conn after Close")
+	}
+}
+
+func TestDialFailsImmediatelyAfterClose(t *testing.T) {
+	s := newTestSession(t, func(context.Context) (*sessionConn, error) {
+		return newFakeConn("conn-1"), nil
+	})
+	s.dialWait = 5 * time.Second
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	_, err := s.DialContext(context.Background(), "tcp", "x.private:80")
+	if err == nil {
+		t.Fatal("Dial succeeded after Close")
+	}
+}
+
+func TestCloseStopsSupervisorAndConns(t *testing.T) {
+	s := newTestSession(t, sequentialOpener())
+
+	first := s.snapshotCurrentForTest()
+	first.markDraining(time.Hour)
+	waitFor(t, time.Second, func() bool { return s.ServerID() == "conn-2" })
+	second := s.snapshotCurrentForTest()
+
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+
+	if !isClosed(first.stopCh) {
+		t.Fatal("first draining conn not closed")
+	}
+	if !isClosed(second.stopCh) {
+		t.Fatal("current conn not closed")
+	}
+	if s.ctx.Err() == nil {
+		t.Fatal("supervisor ctx not canceled")
+	}
+}
+
+func TestDialContextCancelDuringWait(t *testing.T) {
+	first := newFakeConn("conn-1")
+	transient := errors.New("transient")
+	var calls atomic.Int32
+	openFn := func(context.Context) (*sessionConn, error) {
+		i := calls.Add(1)
+		if i == 1 {
+			return first, nil
+		}
+		return nil, transient
+	}
+	s, clk := newTestSessionWithClock(t, openFn)
+	s.dialWait = 5 * time.Second
+
+	first.serverErrCh <- errors.New("boom")
+	waitFor(t, time.Second, func() bool {
+		cur, _, _ := s.snapshot()
+		return cur == nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var (
+		wg  sync.WaitGroup
+		err error
+	)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, err = s.DialContext(ctx, "tcp", "x.private:80")
+	}()
+	waitFor(t, time.Second, func() bool { return clk.NumWaiters() >= 2 })
+	cancel()
+	wg.Wait()
+	if err == nil {
+		t.Fatal("Dial succeeded, want context cancel")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+}
+
+func TestReadControlHandlesPleaseDrain(t *testing.T) {
+	pr, pw := io.Pipe()
+	h := newFakeConn("conn-1")
+	h.controlRespBody = newReadCloseByteReader(pr)
+
+	done := make(chan struct{})
+	go func() {
+		h.readControl()
+		close(done)
+	}()
+	t.Cleanup(func() {
+		_ = pw.Close()
+		waitForChan(t, done, time.Second, "readControl done")
+	})
+
+	_, err := protodelim.MarshalTo(pw, &pbpd.ControlFrame{
+		Frame: &pbpd.ControlFrame_PleaseDrain{
+			PleaseDrain: &pbpd.PleaseDrain{
+				Reason:             "shutting down",
+				GracePeriodSeconds: 7,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("MarshalTo: %v", err)
+	}
+
+	waitFor(t, time.Second, func() bool { return isClosed(h.drainCh) })
+	if h.acceptsStreams() {
+		t.Fatal("admission gate must be closed by the time drainCh closes")
+	}
+	if h.drainGrace != 7*time.Second {
+		t.Fatalf("drainGrace = %v, want 7s", h.drainGrace)
+	}
+}
+
+func TestReadControlSessionErrorWritesServerErr(t *testing.T) {
+	pr, pw := io.Pipe()
+	h := newFakeConn("conn-1")
+	h.controlRespBody = newReadCloseByteReader(pr)
+
+	done := make(chan struct{})
+	go func() {
+		h.readControl()
+		close(done)
+	}()
+	t.Cleanup(func() { _ = pw.Close() })
+
+	_, err := protodelim.MarshalTo(pw, &pbpd.ControlFrame{
+		Frame: &pbpd.ControlFrame_SessionError{
+			SessionError: &pbpd.SessionError{Message: "auth revoked"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("MarshalTo: %v", err)
+	}
+
+	select {
+	case err := <-h.serverErrCh:
+		if err == nil || !strings.Contains(err.Error(), "auth revoked") {
+			t.Fatalf("serverErrCh = %v, want auth revoked", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("serverErrCh did not receive SessionError")
+	}
+	waitForChan(t, done, time.Second, "readControl done")
+}
+
+func TestReadControlEOFSurfacesAsServerErr(t *testing.T) {
+	pr, pw := io.Pipe()
+	h := newFakeConn("conn-1")
+	h.controlRespBody = newReadCloseByteReader(pr)
+
+	done := make(chan struct{})
+	go func() {
+		h.readControl()
+		close(done)
+	}()
+	_ = pw.Close()
+
+	select {
+	case err := <-h.serverErrCh:
+		if !errors.Is(err, io.EOF) {
+			t.Fatalf("serverErrCh = %v, want EOF", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("serverErrCh did not receive EOF")
+	}
+	waitForChan(t, done, time.Second, "readControl done")
+}
+
+func TestDialResponseErrorMapping(t *testing.T) {
+	addr := dialAddr{addr: "x.private:80", host: "x.private", port: 80}
+
+	cases := []struct {
+		name      string
+		status    int
+		errorCode string
+		body      string
+		assert    func(*testing.T, error)
+	}{
+		{
+			name:      "404 maps to DNSError IsNotFound",
+			status:    http.StatusNotFound,
+			errorCode: "ERR_NGROK_706",
+			body:      "endpoint not found",
+			assert: func(t *testing.T, err error) {
+				var dnsErr *net.DNSError
+				if !errors.As(err, &dnsErr) {
+					t.Fatalf("error %T does not wrap *net.DNSError", err)
+				}
+				if !dnsErr.IsNotFound || dnsErr.Name != "x.private" {
+					t.Fatalf("DNSError = %+v", dnsErr)
+				}
+
+				var se *ServerError
+				if !errors.As(err, &se) {
+					t.Fatalf("error %T does not wrap *ServerError", err)
+				}
+				if se.Code != "ERR_NGROK_706" || se.Message != "endpoint not found" || se.Status != http.StatusNotFound {
+					t.Fatalf("ServerError = %+v", se)
+				}
+			},
+		},
+		{
+			name:   "503 maps to ECONNREFUSED",
+			status: http.StatusServiceUnavailable,
+			body:   "no endpoint available",
+			assert: func(t *testing.T, err error) {
+				if !errors.Is(err, syscall.ECONNREFUSED) {
+					t.Fatalf("error = %v, want ECONNREFUSED", err)
+				}
+			},
+		},
+		{
+			name:   "401 maps to ECONNREFUSED",
+			status: http.StatusUnauthorized,
+			body:   "missing bearer token",
+			assert: func(t *testing.T, err error) {
+				if !errors.Is(err, syscall.ECONNREFUSED) {
+					t.Fatalf("error = %v, want ECONNREFUSED", err)
+				}
+			},
+		},
+		{
+			name:   "403 maps to ECONNREFUSED",
+			status: http.StatusForbidden,
+			body:   "invalid token",
+			assert: func(t *testing.T, err error) {
+				if !errors.Is(err, syscall.ECONNREFUSED) {
+					t.Fatalf("error = %v, want ECONNREFUSED", err)
+				}
+			},
+		},
+		{
+			name:   "429 maps to ECONNREFUSED",
+			status: http.StatusTooManyRequests,
+			body:   "rate limited",
+			assert: func(t *testing.T, err error) {
+				if !errors.Is(err, syscall.ECONNREFUSED) {
+					t.Fatalf("error = %v, want ECONNREFUSED", err)
+				}
+			},
+		},
+		{
+			name:   "500 has no sentinel",
+			status: http.StatusInternalServerError,
+			body:   "internal error",
+			assert: func(t *testing.T, err error) {
+				var se *ServerError
+				if !errors.As(err, &se) {
+					t.Fatalf("error %T does not wrap *ServerError", err)
+				}
+				if se.Message != "internal error" || se.Status != http.StatusInternalServerError {
+					t.Fatalf("ServerError = %+v", se)
+				}
+				var dnsErr *net.DNSError
+				if errors.As(err, &dnsErr) {
+					t.Fatalf("unexpected DNSError: %+v", dnsErr)
+				}
+				if errors.Is(err, syscall.ECONNREFUSED) {
+					t.Fatal("unexpected ECONNREFUSED")
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := &http.Response{
+				StatusCode: tc.status,
+				Header:     http.Header{},
+			}
+			if tc.errorCode != "" {
+				resp.Header.Set(dialErrorCodeHeader, tc.errorCode)
+			}
+			err := dialResponseError(resp, addr, tc.body)
+			if err == nil {
+				t.Fatal("dialResponseError returned nil")
+			}
+			var op *net.OpError
+			if !errors.As(err, &op) {
+				t.Fatalf("error %T does not wrap *net.OpError", err)
+			}
+			if op.Op != "dial" || op.Net != "tcp" {
+				t.Fatalf("OpError = %+v", op)
+			}
+			tc.assert(t, err)
+		})
+	}
+}
+
+type manualClock struct {
+	mu     sync.Mutex
+	now    time.Time
+	timers map[*manualTimer]struct{}
+}
+
+func newManualClock(now time.Time) *manualClock {
+	return &manualClock{
+		now:    now,
+		timers: make(map[*manualTimer]struct{}),
+	}
+}
+
+func (c *manualClock) NewTimer(d time.Duration) sessionTimer {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	t := &manualTimer{
+		clock:    c,
+		deadline: c.now.Add(d),
+		ch:       make(chan time.Time, 1),
+	}
+	c.timers[t] = struct{}{}
+	c.fireReadyLocked()
+	return t
+}
+
+func (c *manualClock) Step(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
+	c.fireReadyLocked()
+}
+
+func (c *manualClock) HasWaiters() bool {
+	return c.NumWaiters() > 0
+}
+
+func (c *manualClock) NumWaiters() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.timers)
+}
+
+func (c *manualClock) fireReadyLocked() {
+	for t := range c.timers {
+		if t.stopped || t.fired || t.deadline.After(c.now) {
+			continue
+		}
+		t.fired = true
+		delete(c.timers, t)
+		t.ch <- c.now
+	}
+}
+
+type manualTimer struct {
+	clock    *manualClock
+	deadline time.Time
+	ch       chan time.Time
+	stopped  bool
+	fired    bool
+}
+
+func (t *manualTimer) C() <-chan time.Time {
+	return t.ch
+}
+
+func (t *manualTimer) Stop() bool {
+	t.clock.mu.Lock()
+	defer t.clock.mu.Unlock()
+	if t.stopped || t.fired {
+		return false
+	}
+	t.stopped = true
+	delete(t.clock.timers, t)
+	return true
+}
+
+func (s *Session) snapshotCurrentForTest() *sessionConn {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.current
+}
+
+func idFor(i int32) string {
+	return "conn-" + strconv.Itoa(int(i))
+}
+
+func isClosed(ch <-chan struct{}) bool {
+	select {
+	case <-ch:
+		return true
+	default:
+		return false
+	}
+}
+
+func waitForChan(t *testing.T, ch <-chan struct{}, timeout time.Duration, name string) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(timeout):
+		t.Fatalf("timed out waiting for %s", name)
+	}
+}
+
+var _ = func() bool {
+	err := &net.OpError{Err: &os.SyscallError{Syscall: "connect", Err: syscall.ECONNREFUSED}}
+	return errors.Is(err, syscall.ECONNREFUSED)
+}()


### PR DESCRIPTION
Adapt the private-dial client to keep a logical Session alive across server drain and control-stream failures in ngrok-go while preserving HTTP/2 and HTTP/3 transport selection.

- split Session supervision from per-transport connection state
- reconnect with backoff on drain or abrupt session errors
- preserve in-flight drained streams through server grace
- route new DialContext calls to the freshest usable transport
- use an owned h2 ClientConn instead of HTTP/2 transport pooling
- surface auth rejections as fatal instead of retrying forever