### PR TITLE
privatedial: switch error handling over to trailers

### DIFF
--- a/privatedial/client.go
+++ b/privatedial/client.go
@@ -374,7 +374,20 @@ func (c *Client) race(ctx context.Context) (*Session, error) {
 
 	quicCancel()
 	h2Cancel()
-	return nil, fmt.Errorf("private-dial: both transports failed: quic=%v, h2=%v", quicErr, h2Err)
+	return nil, bothTransportsFailed(quicErr, h2Err)
+}
+
+// bothTransportsFailed combines the per-transport failures from the race into
+// a single error. When both transports failed with the same ngrok error code,
+// the server reported one underlying cause to both attempts, so the result
+// collapses to that error rather than the redundant "quic=X, h2=X" form.
+func bothTransportsFailed(quicErr, h2Err error) error {
+	var qe, he Error
+	if errors.As(quicErr, &qe) && errors.As(h2Err, &he) &&
+		qe.Code() != "" && qe.Code() == he.Code() {
+		return qe
+	}
+	return fmt.Errorf("private-dial: both transports failed: quic=%v, h2=%v", quicErr, h2Err)
 }
 
 // openProtocol builds the transport for p and runs the /session handshake

--- a/privatedial/client.go
+++ b/privatedial/client.go
@@ -502,6 +502,13 @@ func (c *Client) openConn(ctx context.Context, p Protocol) (*sessionConn, error)
 	ack := new(pbpd.SessionAck)
 	if err := protodelimUnmarshaler.UnmarshalFrom(respBody, ack); err != nil {
 		_ = h.close()
+		// The server can reject a session by committing to a 200 and then
+		// reporting the failure via trailers instead of sending a
+		// SessionAck. Because this read is synchronous, that error surfaces
+		// straight out of OpenSession rather than later on ServerErrCh.
+		if rerr := errorFromTrailer(resp.Trailer); rerr != nil {
+			return nil, rerr
+		}
 		return nil, fmt.Errorf("read SessionAck: %w", err)
 	}
 
@@ -512,6 +519,7 @@ func (c *Client) openConn(ctx context.Context, p Protocol) (*sessionConn, error)
 	h.pingInterval = ack.GetPingInterval().AsDuration()
 	h.dialURL = dialURL
 	h.authToken = c.opts.AuthToken
+	h.controlResp = resp
 	h.controlRespBody = respBody
 	h.sendCh = make(chan *pbpd.ControlFrame)
 	h.sendDone = make(chan struct{})
@@ -752,16 +760,16 @@ func (s *Session) ServerErrCh() <-chan error { return s.serverErrCh }
 //
 // The returned net.Conn is a bidirectional byte stream.
 //
-// Server-side dial failures are translated to standard net errors so
-// callers can use errors.Is/As against the usual sentinels:
-//   - "endpoint not found" returns a *net.OpError wrapping
-//     *net.DNSError (with IsNotFound: true) — analogous to a DNS
-//     lookup miss.
-//   - "no endpoint available" / "session draining" returns a
-//     *net.OpError wrapping syscall.ECONNREFUSED — analogous to a
-//     refused TCP connect.
-//   - other non-200 responses return a generic *net.OpError with the
-//     server's error body as the wrapped Err.
+// The server commits to the stream before it knows the dial outcome, so a
+// server-side dial failure is reported via HTTP trailers and surfaces on the
+// first Read of the returned conn (in place of io.EOF) rather than from
+// DialContext itself. That error is a *net.OpError wrapping a
+// privatedial.Error, and — for error codes with a net analogue — also wrapping
+// a standard sentinel so callers can branch with errors.Is/As as before:
+//   - an unauthorized or "session draining" rejection wraps
+//     syscall.ECONNREFUSED — analogous to a refused TCP connect.
+//   - other codes carry no sentinel; recover the ngrok code with
+//     errors.As(err, &nerr) where nerr is a privatedial.Error.
 func (s *Session) DialContext(ctx context.Context, network string, addr string) (net.Conn, error) {
 	if network != "tcp" {
 		// we only support tcp endpoints
@@ -1090,6 +1098,7 @@ type sessionConn struct {
 	dialURL   *url.URL
 	authToken string
 
+	controlResp     *http.Response
 	controlRespBody *readCloseByteReader
 	controlReqBody  *io.PipeWriter
 	controlCancel   context.CancelFunc
@@ -1192,95 +1201,120 @@ func (h *sessionConn) dial(ctx context.Context, addr dialAddr) (net.Conn, error)
 		_ = resp.Body.Close()
 		_ = reqWriter.Close()
 		reqCancel()
-		return nil, dialResponseError(resp, addr, string(snippet))
+		return nil, &net.OpError{
+			Op:   "dial",
+			Net:  addr.Network(),
+			Addr: addr,
+			Err:  fmt.Errorf("private-dial /dial status %d: %s", resp.StatusCode, strings.TrimSpace(string(snippet))),
+		}
 	}
 
 	return &dialConn{
 		remoteAddr: addr,
 		reqBody:    reqWriter,
+		resp:       resp,
 		respBody:   resp.Body,
 		reqCancel:  reqCancel,
 	}, nil
 }
 
-const dialErrorCodeHeader = "Ngrok-Error-Code"
+// The HTTP trailer names a private-dial server uses to report a structured
+// ngrok error when a /dial or /session stream terminates. Because they are
+// trailers, they only become readable once the response body reaches EOF.
+const (
+	dialErrorCodeTrailer    = "Ngrok-Dial-Error-Code"
+	dialErrorMessageTrailer = "Ngrok-Dial-Error-Message"
+)
 
-// dialResponseError translates a non-200 /dial response into a
-// *net.OpError that wraps a *ServerError carrying the structured ngrok
-// error code (when the server sent one). The ServerError's Unwrap
-// chain points at a familiar net sentinel — *net.DNSError for "not
-// found" / 404, syscall.ECONNREFUSED for "no endpoint" / 503, etc. —
-// so callers can use either errors.As(&serverErr) for the ngrok code
-// or errors.Is(err, syscall.ECONNREFUSED) / errors.As(&dnsErr) for
-// generic "couldn't connect" handling.
-func dialResponseError(resp *http.Response, addr dialAddr, body string) error {
-	body = strings.TrimSpace(body)
-	code := resp.Header.Get(dialErrorCodeHeader)
-
-	var sentinel error
-	switch resp.StatusCode {
-	case http.StatusNotFound:
-		sentinel = &net.DNSError{Err: "no such host", Name: addr.host, IsNotFound: true}
-	case http.StatusServiceUnavailable:
-		sentinel = &os.SyscallError{Syscall: "connect", Err: syscall.ECONNREFUSED}
-	case http.StatusUnauthorized, http.StatusForbidden, http.StatusTooManyRequests:
-		// Auth/quota/rate-limit rejections aren't routing failures, but
-		// from the caller's POV "I tried to dial and the server said no"
-		// behaves like ECONNREFUSED — a real connect that was refused.
-		sentinel = &os.SyscallError{Syscall: "connect", Err: syscall.ECONNREFUSED}
-	}
-
-	server := &ServerError{
-		Code:    code,
-		Message: body,
-		Status:  resp.StatusCode,
-		wrapped: sentinel,
-	}
-	return &net.OpError{Op: "dial", Net: addr.Network(), Addr: addr, Err: server}
+// Error is the structured error a private-dial server reports via the
+// dial/session HTTP trailers. It carries the ngrok error code so callers can
+// branch on it; all ngrok error codes are documented at
+// https://ngrok.com/docs/errors.
+//
+// Extract it from any error returned by this package with errors.As:
+//
+//	var nerr privatedial.Error
+//	if errors.As(err, &nerr) {
+//		fmt.Printf("%s: %s\n", nerr.Code(), nerr)
+//	}
+type Error interface {
+	error
+	// Code returns the prefixed ngrok error code (e.g. "ERR_NGROK_706").
+	// It is empty if the server did not send one.
+	Code() string
 }
 
-// ServerError carries the structured error a private-dial server returned
-// on a non-200 /dial response. It is wrapped inside *net.OpError so
-// callers who only care about the broad failure category can use
-// errors.Is / errors.As against the standard net sentinels (e.g.
-// *net.DNSError, syscall.ECONNREFUSED). Callers that want the ngrok
-// error code or the server's human-readable message can extract it via
-// errors.As(err, &serverErr).
-type ServerError struct {
-	// Code is the prefixed ngrok error code (e.g. "ERR_NGROK_706")
-	// extracted from the Ngrok-Error-Code response header. May be
-	// empty if the server did not emit one.
-	Code string
+const ngrokErrorsURL = "https://ngrok.com/docs/errors"
 
-	// Message is the server-provided human-readable description.
-	Message string
-
-	// Status is the HTTP status code of the response.
-	Status int
-
+// serverError is the concrete Error rehydrated from the dial/session trailers.
+// It optionally wraps a net-style sentinel (chosen from its ngrok error code by
+// netSentinelForCode) so callers who only care about the broad failure category
+// can match it with errors.Is/errors.As against the standard net errors — e.g.
+// errors.As(&net.DNSError{}) or errors.Is(err, syscall.ECONNREFUSED) — while
+// errors.As(&privatedial.Error) still recovers the ngrok code.
+type serverError struct {
+	code    string
+	message string
 	// wrapped is the net-style sentinel (*net.DNSError,
-	// *os.SyscallError{ECONNREFUSED}, etc.) used for errors.Is /
-	// errors.As composition. It is purely a type-match anchor; its
-	// own Error() text is not included in ServerError.Error().
+	// *os.SyscallError{ECONNREFUSED}, ...) this error code maps to, or nil
+	// when the code has no net analogue. It is purely a type/Is match anchor;
+	// its own text is not part of Error().
 	wrapped error
 }
 
-func (e *ServerError) Error() string {
-	switch {
-	case e.Code != "" && e.Message != "":
-		return fmt.Sprintf("%s: %s", e.Code, e.Message)
-	case e.Code != "":
-		return e.Code
-	case e.Message != "":
-		return e.Message
+func (e *serverError) Code() string { return e.code }
+
+func (e *serverError) Error() string {
+	msg := e.message
+	if e.code != "" {
+		if msg == "" {
+			msg = e.code
+		}
+		return fmt.Sprintf("%s\n\n%s/%s", msg, ngrokErrorsURL, strings.ToLower(e.code))
+	}
+	return msg
+}
+
+// Unwrap returns the net-style sentinel chosen for this error's ngrok code, so
+// errors.Is/errors.As walks down to it.
+func (e *serverError) Unwrap() error { return e.wrapped }
+
+// Private-dial ngrok error codes that carry a net-level analogue. The server
+// reports exactly these two on a dial/session trailer, and both behave like a
+// refused connect from the caller's POV — mirroring the old status-based
+// mapping (an unauthorized 401/403 or a "session draining" 503 -> ECONNREFUSED).
+const (
+	errCodeUnauthorized    = "ERR_NGROK_709"
+	errCodeSessionDraining = "ERR_NGROK_742"
+)
+
+// netSentinelForCode maps a private-dial ngrok error code to the net-style
+// sentinel that best matches it. The two codes with a net analogue both behave
+// like a refused connect; any other code has no sentinel, leaving the failure
+// to surface only as an Error.
+func netSentinelForCode(code string) error {
+	switch code {
+	case errCodeUnauthorized, errCodeSessionDraining:
+		return &os.SyscallError{Syscall: "connect", Err: syscall.ECONNREFUSED}
 	default:
-		return fmt.Sprintf("private-dial server returned %d", e.Status)
+		return nil
 	}
 }
 
-// Unwrap returns the standard-library sentinel error chosen for this
-// ServerError's status code, so errors.Is / errors.As walks down to it.
-func (e *ServerError) Unwrap() error { return e.wrapped }
+// errorFromTrailer rehydrates the structured ngrok error a private-dial server
+// reported via the HTTP trailers of a /dial or /session response. It returns
+// nil when the trailers carry no error, so a clean stream termination is
+// distinguishable from a server-reported failure. The trailers are only
+// populated once the corresponding response body has been read to EOF.
+//
+func errorFromTrailer(trailer http.Header) Error {
+	code := trailer.Get(dialErrorCodeTrailer)
+	message := strings.TrimSpace(trailer.Get(dialErrorMessageTrailer))
+	if code == "" && message == "" {
+		return nil
+	}
+	return &serverError{code: code, message: message, wrapped: netSentinelForCode(code)}
+}
 
 func (h *sessionConn) markClosed() {
 	h.lifeMu.Lock()
@@ -1437,6 +1471,17 @@ func (h *sessionConn) readControl() {
 		frame := new(pbpd.ControlFrame)
 		if err := protodelimUnmarshaler.UnmarshalFrom(h.controlRespBody, frame); err != nil {
 			if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+				// The control stream ended. Its trailers are now readable;
+				// a server-reported error preempts the plain io.EOF the
+				// deferred send would otherwise forward.
+				if h.controlResp != nil {
+					if rerr := errorFromTrailer(h.controlResp.Trailer); rerr != nil {
+						select {
+						case h.serverErrCh <- rerr:
+						default:
+						}
+					}
+				}
 				return
 			}
 			select {
@@ -1470,11 +1515,16 @@ func (h *sessionConn) readControl() {
 
 // dialConn is the net.Conn returned from Session.DialContext. Read pulls
 // from the response body; Write pushes into the request body. Close terminates
-// both sides. Dial-level failures never reach a dialConn — they're returned
-// from DialContext directly as *net.OpError. EOF on Read surfaces normally as
-// io.EOF.
+// both sides.
+//
+// Because the server commits to a 200 before it knows whether the dial will
+// succeed, dial failures are reported via HTTP trailers that only become
+// readable once the response body reaches EOF. Read therefore inspects the
+// trailers on EOF: a server-reported failure surfaces as a privatedial.Error
+// in place of io.EOF, while a clean stream termination surfaces as io.EOF.
 type dialConn struct {
 	reqBody   *io.PipeWriter
+	resp      *http.Response
 	respBody  io.ReadCloser
 	reqCancel context.CancelFunc
 
@@ -1483,7 +1533,19 @@ type dialConn struct {
 	closeOnce sync.Once
 }
 
-func (c *dialConn) Read(p []byte) (int, error)  { return c.respBody.Read(p) }
+func (c *dialConn) Read(p []byte) (int, error) {
+	n, err := c.respBody.Read(p)
+	if errors.Is(err, io.EOF) {
+		if rerr := errorFromTrailer(c.resp.Trailer); rerr != nil {
+			// Wrap as *net.OpError so the failure category (the net
+			// sentinel netSentinelForCode chose) bubbles via errors.Is /
+			// errors.As just as the old status-based dial error did.
+			return n, &net.OpError{Op: "dial", Net: c.remoteAddr.Network(), Addr: c.remoteAddr, Err: rerr}
+		}
+	}
+	return n, err
+}
+
 func (c *dialConn) Write(p []byte) (int, error) { return c.reqBody.Write(p) }
 
 // CloseWrite signals end-of-request to the server by closing the request

--- a/privatedial/client_integration_test.go
+++ b/privatedial/client_integration_test.go
@@ -9,12 +9,15 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"errors"
 	"fmt"
 	"io"
 	"math/big"
 	"net"
 	"net/http"
+	"strings"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
@@ -250,6 +253,139 @@ func TestDialEcho(t *testing.T) {
 			}
 			if string(got) != string(payload) {
 				t.Fatalf("echo mismatch: got %q want %q", got, payload)
+			}
+		})
+	}
+}
+
+// TestDialTrailerError proves an end-to-end dial failure reported via HTTP
+// trailers is rehydrated into a privatedial.Error and surfaced on the first
+// Read of the returned conn (the server commits to a 200 before it knows the
+// dial outcome, so the error can only ride out on the trailers).
+func TestDialTrailerError(t *testing.T) {
+	cert := genTLSCert(t)
+
+	dialErrorHandler := func() http.Handler {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/session", func(w http.ResponseWriter, r *http.Request) {
+			var req pbpd.SessionReq
+			if err := protodelimUnmarshaler.UnmarshalFrom(bufio.NewReader(r.Body), &req); err != nil {
+				http.Error(w, "bad SessionReq", http.StatusBadRequest)
+				return
+			}
+			if _, err := protodelim.MarshalTo(w, &pbpd.SessionAck{ServerId: "trailer-srv"}); err != nil {
+				return
+			}
+			flush(w)
+			<-r.Context().Done()
+		})
+		mux.HandleFunc("/dial", func(w http.ResponseWriter, r *http.Request) {
+			var dreq pbpd.DialReq
+			if err := protodelimUnmarshaler.UnmarshalFrom(bufio.NewReader(r.Body), &dreq); err != nil {
+				http.Error(w, "bad DialReq", http.StatusBadRequest)
+				return
+			}
+			// Commit to a 200, then report the dial failure via trailers
+			// with no body, mirroring an immediate server-side failure.
+			w.Header().Set(http.TrailerPrefix+dialErrorCodeTrailer, errCodeSessionDraining)
+			w.Header().Set(http.TrailerPrefix+dialErrorMessageTrailer, "session draining")
+			w.WriteHeader(http.StatusOK)
+			flush(w)
+		})
+		return mux
+	}
+
+	for _, tc := range []struct {
+		name  string
+		proto Protocol
+	}{
+		{"h2", ProtocolH2},
+		{"quic", ProtocolQUIC},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resetSticky()
+			sess := mustOpenSession(t, clientOptsForProtocol(t, tc.proto, cert, dialErrorHandler()))
+			defer sess.Close()
+
+			conn := mustDial(t, sess, "foo.private:80")
+			defer conn.Close()
+
+			_, err := io.ReadAll(conn)
+			if err == nil {
+				t.Fatal("Read succeeded, want trailer error")
+			}
+			if errors.Is(err, io.EOF) {
+				t.Fatalf("Read returned io.EOF, want trailer error")
+			}
+			var nerr Error
+			if !errors.As(err, &nerr) {
+				t.Fatalf("error %T not assignable to privatedial.Error", err)
+			}
+			if nerr.Code() != errCodeSessionDraining {
+				t.Fatalf("Code() = %q, want %q", nerr.Code(), errCodeSessionDraining)
+			}
+			if !strings.Contains(nerr.Error(), "session draining") {
+				t.Fatalf("Error() = %q, want to contain message", nerr.Error())
+			}
+			// The code's net sentinel must bubble end-to-end.
+			if !errors.Is(err, syscall.ECONNREFUSED) {
+				t.Fatalf("want ECONNREFUSED to bubble, got %v", err)
+			}
+		})
+	}
+}
+
+// TestSessionTrailerError proves that a session rejected via trailers (a 200
+// with an error trailer and no SessionAck) is rehydrated and returned straight
+// out of OpenSession, since the handshake reads the SessionAck synchronously.
+func TestSessionTrailerError(t *testing.T) {
+	cert := genTLSCert(t)
+
+	sessionErrorHandler := func() http.Handler {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/session", func(w http.ResponseWriter, r *http.Request) {
+			var req pbpd.SessionReq
+			if err := protodelimUnmarshaler.UnmarshalFrom(bufio.NewReader(r.Body), &req); err != nil {
+				http.Error(w, "bad SessionReq", http.StatusBadRequest)
+				return
+			}
+			// Commit to a 200, then reject via trailers without ever
+			// sending a SessionAck.
+			w.Header().Set(http.TrailerPrefix+dialErrorCodeTrailer, "ERR_NGROK_4040")
+			w.Header().Set(http.TrailerPrefix+dialErrorMessageTrailer, "session rejected")
+			w.WriteHeader(http.StatusOK)
+			flush(w)
+		})
+		return mux
+	}
+
+	for _, tc := range []struct {
+		name  string
+		proto Protocol
+	}{
+		{"h2", ProtocolH2},
+		{"quic", ProtocolQUIC},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resetSticky()
+			opts := clientOptsForProtocol(t, tc.proto, cert, sessionErrorHandler())
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			sess, err := NewClient(opts).OpenSession(ctx)
+			if err == nil {
+				_ = sess.Close()
+				t.Fatal("OpenSession succeeded, want trailer error")
+			}
+			var nerr Error
+			if !errors.As(err, &nerr) {
+				t.Fatalf("error %T not assignable to privatedial.Error: %v", err, err)
+			}
+			if nerr.Code() != "ERR_NGROK_4040" {
+				t.Fatalf("Code() = %q, want ERR_NGROK_4040", nerr.Code())
+			}
+			if !strings.Contains(nerr.Error(), "session rejected") {
+				t.Fatalf("Error() = %q, want to contain message", nerr.Error())
 			}
 		})
 	}

--- a/privatedial/client_test.go
+++ b/privatedial/client_test.go
@@ -628,125 +628,135 @@ func TestReadControlEOFSurfacesAsServerErr(t *testing.T) {
 	waitForChan(t, done, time.Second, "readControl done")
 }
 
-func TestDialResponseErrorMapping(t *testing.T) {
-	addr := dialAddr{addr: "x.private:80", host: "x.private", port: 80}
-
+func TestErrorFromTrailer(t *testing.T) {
 	cases := []struct {
 		name      string
-		status    int
-		errorCode string
-		body      string
-		assert    func(*testing.T, error)
+		code      string
+		message   string
+		wantNil   bool
+		wantCode  string
+		wantMsg   string // substring expected in Error()
+		wantRefus bool   // expect syscall.ECONNREFUSED to bubble
 	}{
 		{
-			name:      "404 maps to DNSError IsNotFound",
-			status:    http.StatusNotFound,
-			errorCode: "ERR_NGROK_706",
-			body:      "endpoint not found",
-			assert: func(t *testing.T, err error) {
-				var dnsErr *net.DNSError
-				if !errors.As(err, &dnsErr) {
-					t.Fatalf("error %T does not wrap *net.DNSError", err)
-				}
-				if !dnsErr.IsNotFound || dnsErr.Name != "x.private" {
-					t.Fatalf("DNSError = %+v", dnsErr)
-				}
-
-				var se *ServerError
-				if !errors.As(err, &se) {
-					t.Fatalf("error %T does not wrap *ServerError", err)
-				}
-				if se.Code != "ERR_NGROK_706" || se.Message != "endpoint not found" || se.Status != http.StatusNotFound {
-					t.Fatalf("ServerError = %+v", se)
-				}
-			},
+			name:      "unauthorized maps to ECONNREFUSED",
+			code:      errCodeUnauthorized,
+			message:   "unauthorized",
+			wantCode:  errCodeUnauthorized,
+			wantMsg:   "unauthorized",
+			wantRefus: true,
 		},
 		{
-			name:   "503 maps to ECONNREFUSED",
-			status: http.StatusServiceUnavailable,
-			body:   "no endpoint available",
-			assert: func(t *testing.T, err error) {
-				if !errors.Is(err, syscall.ECONNREFUSED) {
-					t.Fatalf("error = %v, want ECONNREFUSED", err)
-				}
-			},
+			name:      "session draining maps to ECONNREFUSED",
+			code:      errCodeSessionDraining,
+			message:   "session draining",
+			wantCode:  errCodeSessionDraining,
+			wantMsg:   "session draining",
+			wantRefus: true,
 		},
 		{
-			name:   "401 maps to ECONNREFUSED",
-			status: http.StatusUnauthorized,
-			body:   "missing bearer token",
-			assert: func(t *testing.T, err error) {
-				if !errors.Is(err, syscall.ECONNREFUSED) {
-					t.Fatalf("error = %v, want ECONNREFUSED", err)
-				}
-			},
+			name:     "unmapped code carries no sentinel",
+			code:     "ERR_NGROK_9999",
+			message:  "some other failure",
+			wantCode: "ERR_NGROK_9999",
+			wantMsg:  "some other failure",
 		},
 		{
-			name:   "403 maps to ECONNREFUSED",
-			status: http.StatusForbidden,
-			body:   "invalid token",
-			assert: func(t *testing.T, err error) {
-				if !errors.Is(err, syscall.ECONNREFUSED) {
-					t.Fatalf("error = %v, want ECONNREFUSED", err)
-				}
-			},
+			name:    "message only",
+			message: "no endpoint available",
+			wantMsg: "no endpoint available",
 		},
 		{
-			name:   "429 maps to ECONNREFUSED",
-			status: http.StatusTooManyRequests,
-			body:   "rate limited",
-			assert: func(t *testing.T, err error) {
-				if !errors.Is(err, syscall.ECONNREFUSED) {
-					t.Fatalf("error = %v, want ECONNREFUSED", err)
-				}
-			},
-		},
-		{
-			name:   "500 has no sentinel",
-			status: http.StatusInternalServerError,
-			body:   "internal error",
-			assert: func(t *testing.T, err error) {
-				var se *ServerError
-				if !errors.As(err, &se) {
-					t.Fatalf("error %T does not wrap *ServerError", err)
-				}
-				if se.Message != "internal error" || se.Status != http.StatusInternalServerError {
-					t.Fatalf("ServerError = %+v", se)
-				}
-				var dnsErr *net.DNSError
-				if errors.As(err, &dnsErr) {
-					t.Fatalf("unexpected DNSError: %+v", dnsErr)
-				}
-				if errors.Is(err, syscall.ECONNREFUSED) {
-					t.Fatal("unexpected ECONNREFUSED")
-				}
-			},
+			name:    "empty trailers are not an error",
+			wantNil: true,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			resp := &http.Response{
-				StatusCode: tc.status,
-				Header:     http.Header{},
+			trailer := http.Header{}
+			if tc.code != "" {
+				trailer.Set(dialErrorCodeTrailer, tc.code)
 			}
-			if tc.errorCode != "" {
-				resp.Header.Set(dialErrorCodeHeader, tc.errorCode)
+			if tc.message != "" {
+				trailer.Set(dialErrorMessageTrailer, tc.message)
 			}
-			err := dialResponseError(resp, addr, tc.body)
+
+			err := errorFromTrailer(trailer)
+			if tc.wantNil {
+				if err != nil {
+					t.Fatalf("errorFromTrailer = %v, want nil", err)
+				}
+				return
+			}
 			if err == nil {
-				t.Fatal("dialResponseError returned nil")
+				t.Fatal("errorFromTrailer returned nil")
 			}
-			var op *net.OpError
-			if !errors.As(err, &op) {
-				t.Fatalf("error %T does not wrap *net.OpError", err)
+			if err.Code() != tc.wantCode {
+				t.Fatalf("Code() = %q, want %q", err.Code(), tc.wantCode)
 			}
-			if op.Op != "dial" || op.Net != "tcp" {
-				t.Fatalf("OpError = %+v", op)
+			if !strings.Contains(err.Error(), tc.wantMsg) {
+				t.Fatalf("Error() = %q, want substring %q", err.Error(), tc.wantMsg)
 			}
-			tc.assert(t, err)
+			// The rehydrated error must be extractable via the public
+			// Error interface using errors.As.
+			var nerr Error
+			if !errors.As(err, &nerr) {
+				t.Fatalf("error %T not assignable to privatedial.Error", err)
+			}
+			if tc.wantCode != "" && !strings.Contains(err.Error(), ngrokErrorsURL) {
+				t.Fatalf("Error() = %q, want docs URL when a code is present", err.Error())
+			}
+			if gotRefus := errors.Is(err, syscall.ECONNREFUSED); gotRefus != tc.wantRefus {
+				t.Fatalf("errors.Is(ECONNREFUSED) = %v, want %v", gotRefus, tc.wantRefus)
+			}
 		})
 	}
+}
+
+// TestDialConnReadSurfacesTrailerError proves a dialConn surfaces a
+// server-reported trailer error in place of io.EOF, while a clean stream
+// termination still surfaces as io.EOF.
+func TestDialConnReadSurfacesTrailerError(t *testing.T) {
+	t.Run("trailer error preempts EOF", func(t *testing.T) {
+		addr := dialAddr{addr: "x.private:80", host: "x.private", port: 80}
+		resp := &http.Response{Trailer: http.Header{}}
+		resp.Trailer.Set(dialErrorCodeTrailer, errCodeSessionDraining)
+		resp.Trailer.Set(dialErrorMessageTrailer, "session draining")
+		c := &dialConn{remoteAddr: addr, resp: resp, respBody: io.NopCloser(strings.NewReader(""))}
+
+		_, err := c.Read(make([]byte, 8))
+		if errors.Is(err, io.EOF) {
+			t.Fatalf("Read returned io.EOF, want trailer error")
+		}
+
+		// The dial failure must surface as a *net.OpError wrapping the
+		// ngrok Error and the net sentinel, just like the old path.
+		var op *net.OpError
+		if !errors.As(err, &op) {
+			t.Fatalf("error %T does not wrap *net.OpError", err)
+		}
+		if op.Op != "dial" || op.Net != "tcp" {
+			t.Fatalf("OpError = %+v", op)
+		}
+		var nerr Error
+		if !errors.As(err, &nerr) {
+			t.Fatalf("error %T not assignable to privatedial.Error", err)
+		}
+		if nerr.Code() != errCodeSessionDraining {
+			t.Fatalf("Code() = %q", nerr.Code())
+		}
+		if !errors.Is(err, syscall.ECONNREFUSED) {
+			t.Fatalf("want ECONNREFUSED to bubble, got %v", err)
+		}
+	})
+
+	t.Run("clean EOF without trailer", func(t *testing.T) {
+		c := &dialConn{resp: &http.Response{Trailer: http.Header{}}, respBody: io.NopCloser(strings.NewReader(""))}
+		if _, err := c.Read(make([]byte, 8)); !errors.Is(err, io.EOF) {
+			t.Fatalf("Read = %v, want io.EOF", err)
+		}
+	})
 }
 
 type manualClock struct {

--- a/privatedial/client_test.go
+++ b/privatedial/client_test.go
@@ -759,6 +759,40 @@ func TestDialConnReadSurfacesTrailerError(t *testing.T) {
 	})
 }
 
+func TestBothTransportsFailed(t *testing.T) {
+	sameQUIC := &serverError{code: "ERR_NGROK_4040", message: "rejected via quic"}
+	sameH2 := &serverError{code: "ERR_NGROK_4040", message: "rejected via h2"}
+
+	t.Run("same code collapses to one error", func(t *testing.T) {
+		err := bothTransportsFailed(sameQUIC, sameH2)
+		var nerr Error
+		if !errors.As(err, &nerr) {
+			t.Fatalf("error %T not assignable to privatedial.Error", err)
+		}
+		if nerr.Code() != "ERR_NGROK_4040" {
+			t.Fatalf("Code() = %q", nerr.Code())
+		}
+		if strings.Contains(err.Error(), "both transports failed") {
+			t.Fatalf("error should not mention both transports: %q", err.Error())
+		}
+	})
+
+	t.Run("different codes keep both", func(t *testing.T) {
+		other := &serverError{code: "ERR_NGROK_706", message: "not found"}
+		err := bothTransportsFailed(sameQUIC, other)
+		if !strings.Contains(err.Error(), "both transports failed") {
+			t.Fatalf("want combined error, got %q", err.Error())
+		}
+	})
+
+	t.Run("missing codes keep both", func(t *testing.T) {
+		err := bothTransportsFailed(errors.New("quic boom"), errors.New("h2 boom"))
+		if !strings.Contains(err.Error(), "quic=quic boom") || !strings.Contains(err.Error(), "h2=h2 boom") {
+			t.Fatalf("want combined error, got %q", err.Error())
+		}
+	})
+}
+
 type manualClock struct {
 	mu     sync.Mutex
 	now    time.Time


### PR DESCRIPTION
We originally speced out trailers as the mechanism for sending the error code / message, and then the initial MVP didn't do that but instead used http status codes and such.

The usual downside with http trailers is that they're not supported well in http/1, browsers, and some libraries, but this is an internal protocol where we control the client and server, so we can just insist on http/2 or 3 (as we do), and also only use libraries that deal with em correctly (as we do currently).

With those downsides out of the way, the upsides are quite nice since they let the server-side be simpler, and they're less ambiguous to parse client-side.

Let's switch over to em.