### PR TITLE
privatedial: speed up reconnect after network outage

### DIFF
--- a/internal/legacy/online_test.go
+++ b/internal/legacy/online_test.go
@@ -152,7 +152,7 @@ func TestTCP(t *testing.T) {
 	url, err := url.Parse(tun.URL())
 	require.NoError(t, err)
 	url.Scheme = "http"
-	resp, err := http.Get(url.String())
+	resp, err := getTunnelURL(ctx, url.String())
 	require.NoError(t, err, "GET tunnel url")
 	defer resp.Body.Close()
 
@@ -163,6 +163,48 @@ func TestTCP(t *testing.T) {
 
 	require.NoError(t, tun.CloseWithContext(ctx))
 	expectChanError(t, exited, 5*time.Second)
+}
+
+func getTunnelURL(ctx context.Context, url string) (*http.Response, error) {
+	const (
+		retryFor     = 5 * time.Second
+		initialDelay = 25 * time.Millisecond
+		maxDelay     = 250 * time.Millisecond
+	)
+
+	ctx, cancel := context.WithTimeout(ctx, retryFor)
+	defer cancel()
+
+	delay := initialDelay
+	var lastErr error
+	for {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil {
+			return resp, nil
+		}
+		if resp != nil && resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+		lastErr = err
+
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, lastErr
+		case <-timer.C:
+		}
+
+		delay *= 2
+		if delay > maxDelay {
+			delay = maxDelay
+		}
+	}
 }
 
 func TestConnectionCallbacks(t *testing.T) {

--- a/privatedial/client.go
+++ b/privatedial/client.go
@@ -74,7 +74,15 @@ const (
 	// HTTP/2 attempt is staggered in. If QUIC completes within this window
 	// no second connection is ever made.
 	quicHeadStart = 250 * time.Millisecond
+
+	h2ReadIdleTimeout = 10 * time.Second
+	h2PingTimeout     = 5 * time.Second
+
+	quicKeepAlivePeriod = h2ReadIdleTimeout
+	quicMaxIdleTimeout  = h2ReadIdleTimeout + h2PingTimeout
 )
+
+var errDialWaitTimeout = errors.New("private-dial: dial wait timeout")
 
 // stickyProtocol records the first protocol the race settled on in this
 // process. Once set, every subsequent connect (including reconnects) reuses
@@ -553,8 +561,8 @@ func (d *Dialer) newH2Transport(ctx context.Context) (roundTripCloser, string, e
 	}
 	remoteAddr := tlsConn.RemoteAddr().String()
 	transport := &http2.Transport{
-		ReadIdleTimeout: 30 * time.Second,
-		PingTimeout:     15 * time.Second,
+		ReadIdleTimeout: h2ReadIdleTimeout,
+		PingTimeout:     h2PingTimeout,
 	}
 	cc, err := transport.NewClientConn(tlsConn)
 	if err != nil {
@@ -565,15 +573,16 @@ func (d *Dialer) newH2Transport(ctx context.Context) (roundTripCloser, string, e
 }
 
 // newH3Transport builds the HTTP/3 (QUIC) transport and records the server
-// address the QUIC connection lands on. KeepAlivePeriod is the QUIC analogue
-// of the h2 keepalive PINGs: it keeps the single multiplexing connection alive
-// and surfaces a dead peer to stuck stream writers.
+// address the QUIC connection lands on. QUIC does not expose separate read-idle
+// and ping timeouts like HTTP/2, so bound its idle timeout and send keepalives
+// on the same cadence as h2's read-idle probes.
 func (d *Dialer) newH3Transport() (roundTripCloser, *connAddrRecorder) {
 	rec := &connAddrRecorder{}
 	t := &http3.Transport{
 		TLSClientConfig: d.tlsConfigFor(d.cfg.QUICServerAddr, "h3"),
 		QUICConfig: &quic.Config{
-			KeepAlivePeriod: 30 * time.Second,
+			KeepAlivePeriod: quicKeepAlivePeriod,
+			MaxIdleTimeout:  quicMaxIdleTimeout,
 		},
 	}
 	t.Dial = func(ctx context.Context, addr string, tlsCfg *tls.Config, cfg *quic.Config) (*quic.Conn, error) {
@@ -692,7 +701,7 @@ func (d *Dialer) Connect(ctx context.Context) error {
 	if err := d.ensureConnected(ctx); err != nil {
 		return err
 	}
-	_, err := d.waitForCurrent(ctx, nil)
+	_, err := d.waitForCurrent(ctx)
 	return err
 }
 
@@ -860,11 +869,18 @@ func (d *Dialer) DialContext(ctx context.Context, network string, addr string) (
 }
 
 func (d *Dialer) dial(ctx context.Context, addr dialAddr) (net.Conn, error) {
-	timer := d.sessionClock().NewTimer(d.dialWaitTimeout())
-	defer timer.Stop()
+	// budgetCtx bounds the entire dial: both the wait for a usable conn and the
+	// per-conn RoundTrip. The cause lets us map our own budget expiry to a
+	// refused connect without treating caller cancellation the same way.
+	budgetCtx, cancel := context.WithTimeoutCause(ctx, d.dialWaitTimeout(), errDialWaitTimeout)
+	defer cancel()
+
+	dialBudgetExpired := func() bool {
+		return errors.Is(context.Cause(budgetCtx), errDialWaitTimeout)
+	}
 
 	dialErrFor := func(err error) error {
-		if ctx.Err() == nil && errors.Is(err, context.DeadlineExceeded) {
+		if ctx.Err() == nil && (dialBudgetExpired() || errors.Is(err, context.DeadlineExceeded)) {
 			return &net.OpError{
 				Op:   "dial",
 				Net:  addr.Network(),
@@ -876,21 +892,22 @@ func (d *Dialer) dial(ctx context.Context, addr dialAddr) (net.Conn, error) {
 	}
 
 	for {
-		select {
-		case <-timer.C():
-			return nil, dialErrFor(context.DeadlineExceeded)
-		default:
-		}
 		if err := ctx.Err(); err != nil {
 			return nil, dialErrFor(err)
 		}
-		cur, err := d.waitForCurrent(ctx, timer.C())
+		if dialBudgetExpired() {
+			return nil, dialErrFor(context.DeadlineExceeded)
+		}
+		cur, err := d.waitForCurrent(budgetCtx)
 		if err != nil {
 			return nil, dialErrFor(err)
 		}
-		conn, dialErr := cur.dial(ctx, addr)
+		conn, dialErr := cur.dial(budgetCtx, addr)
 		if dialErr == nil {
 			return conn, nil
+		}
+		if dialBudgetExpired() {
+			return nil, dialErrFor(context.DeadlineExceeded)
 		}
 		if errors.Is(dialErr, context.Canceled) || errors.Is(dialErr, context.DeadlineExceeded) {
 			return nil, dialErr
@@ -902,7 +919,7 @@ func (d *Dialer) dial(ctx context.Context, addr dialAddr) (net.Conn, error) {
 	}
 }
 
-func (d *Dialer) waitForCurrent(ctx context.Context, budget <-chan time.Time) (*sessionConn, error) {
+func (d *Dialer) waitForCurrent(ctx context.Context) (*sessionConn, error) {
 	for {
 		if err := d.ctx.Err(); err != nil {
 			return nil, ErrSessionClosed
@@ -918,8 +935,6 @@ func (d *Dialer) waitForCurrent(ctx context.Context, budget <-chan time.Time) (*
 		case <-ready:
 		case <-ctx.Done():
 			return nil, ctx.Err()
-		case <-budget:
-			return nil, context.DeadlineExceeded
 		case <-d.ctx.Done():
 			return nil, ErrSessionClosed
 		}
@@ -1367,7 +1382,6 @@ func netSentinelForCode(code string) error {
 // nil when the trailers carry no error, so a clean stream termination is
 // distinguishable from a server-reported failure. The trailers are only
 // populated once the corresponding response body has been read to EOF.
-//
 func errorFromTrailer(trailer http.Header) Error {
 	code := trailer.Get(dialErrorCodeTrailer)
 	message := strings.TrimSpace(trailer.Get(dialErrorMessageTrailer))

--- a/privatedial/client_test.go
+++ b/privatedial/client_test.go
@@ -1,6 +1,7 @@
 package privatedial
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"io"
@@ -14,6 +15,7 @@ import (
 	"sync/atomic"
 	"syscall"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"google.golang.org/protobuf/encoding/protodelim"
@@ -55,19 +57,33 @@ func newTestSessionWithClock(t *testing.T, openFn func(context.Context) (*sessio
 	ctx, cancel := context.WithCancel(context.Background())
 	clk := newManualClock(time.Now())
 	s := &Dialer{
-		ctx:         ctx,
-		cancel:      cancel,
-		proto:       ProtocolH2,
-		ready:       make(chan struct{}),
-		connected:   true,
-		current:     first,
-		openFn:      openFn,
-		clock:       clk,
-		done:        make(chan struct{}),
+		ctx:       ctx,
+		cancel:    cancel,
+		proto:     ProtocolH2,
+		ready:     make(chan struct{}),
+		connected: true,
+		current:   first,
+		openFn:    openFn,
+		clock:     clk,
+		done:      make(chan struct{}),
 	}
 	go s.supervise()
 	t.Cleanup(func() { _ = s.Close() })
 	return s, clk
+}
+
+func newBareDialerForTest(current *sessionConn, dialWait time.Duration) *Dialer {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &Dialer{
+		ctx:       ctx,
+		cancel:    cancel,
+		proto:     ProtocolH2,
+		ready:     make(chan struct{}),
+		connected: true,
+		current:   current,
+		dialWait:  dialWait,
+		done:      make(chan struct{}),
+	}
 }
 
 func TestReconnectBacksOffAfterTransientOpenError(t *testing.T) {
@@ -216,40 +232,34 @@ func TestAuthFatalStopsReconnect(t *testing.T) {
 }
 
 func TestDialBlocksThenTimesOutWhenNoCurrent(t *testing.T) {
-	first := newFakeConn("conn-1")
-	transient := errors.New("transient")
-	var calls atomic.Int32
-	openFn := func(context.Context) (*sessionConn, error) {
-		i := calls.Add(1)
-		if i == 1 {
-			return first, nil
+	synctest.Test(t, func(t *testing.T) {
+		s := newBareDialerForTest(nil, 80*time.Millisecond)
+		defer s.Close() //nolint:errcheck
+
+		errCh := make(chan error, 1)
+		go func() {
+			_, err := s.DialContext(context.Background(), "tcp", "x.private:80")
+			errCh <- err
+		}()
+
+		synctest.Wait()
+		select {
+		case err := <-errCh:
+			t.Fatalf("Dial returned before timeout: %v", err)
+		default:
 		}
-		return nil, transient
-	}
-	s, clk := newTestSessionWithClock(t, openFn)
-	s.dialWait = 80 * time.Millisecond
 
-	first.serverErrCh <- errors.New("boom")
-	waitFor(t, time.Second, func() bool {
-		cur, _, _ := s.snapshot()
-		return cur == nil
+		time.Sleep(80 * time.Millisecond)
+		synctest.Wait()
+
+		err := <-errCh
+		if err == nil {
+			t.Fatal("Dial succeeded, want timeout")
+		}
+		if !errors.Is(err, syscall.ECONNREFUSED) {
+			t.Fatalf("error = %v, want ECONNREFUSED", err)
+		}
 	})
-
-	errCh := make(chan error, 1)
-	go func() {
-		_, err := s.DialContext(context.Background(), "tcp", "x.private:80")
-		errCh <- err
-	}()
-	waitFor(t, time.Second, func() bool { return clk.NumWaiters() >= 2 })
-	clk.Step(80 * time.Millisecond)
-
-	err := <-errCh
-	if err == nil {
-		t.Fatal("Dial succeeded, want timeout")
-	}
-	if !errors.Is(err, syscall.ECONNREFUSED) {
-		t.Fatalf("error = %v, want ECONNREFUSED", err)
-	}
 }
 
 func TestWaitForCurrentWakesOnReconnect(t *testing.T) {
@@ -281,7 +291,7 @@ func TestWaitForCurrentWakesOnReconnect(t *testing.T) {
 	}
 	out := make(chan result, 1)
 	go func() {
-		cur, err := s.waitForCurrent(context.Background(), make(chan time.Time))
+		cur, err := s.waitForCurrent(context.Background())
 		out <- result{cur: cur, err: err}
 	}()
 
@@ -348,43 +358,37 @@ func TestCloseDuringReconnectDiscardsLateConn(t *testing.T) {
 }
 
 func TestDialSkipsDrainedCurrent(t *testing.T) {
-	first := newFakeConn("conn-1")
-	clk := newManualClock(time.Now())
-	openFn := func(context.Context) (*sessionConn, error) {
-		return first, nil
-	}
-	ctx, cancel := context.WithCancel(context.Background())
-	s := &Dialer{
-		ctx:         ctx,
-		cancel:      cancel,
-		proto:       ProtocolH2,
-		ready:       make(chan struct{}),
-		connected:   true,
-		current:     first,
-		openFn:      openFn,
-		clock:       clk,
-		dialWait:    200 * time.Millisecond,
-		done:        make(chan struct{}),
-	}
-	t.Cleanup(func() { _ = s.Close() })
+	synctest.Test(t, func(t *testing.T) {
+		first := newFakeConn("conn-1")
+		s := newBareDialerForTest(first, 200*time.Millisecond)
+		defer s.Close() //nolint:errcheck
 
-	first.markDraining(time.Second)
+		first.markDraining(time.Second)
 
-	errCh := make(chan error, 1)
-	go func() {
-		_, err := s.DialContext(context.Background(), "tcp", "x.private:80")
-		errCh <- err
-	}()
-	waitFor(t, time.Second, clk.HasWaiters)
-	clk.Step(200 * time.Millisecond)
+		errCh := make(chan error, 1)
+		go func() {
+			_, err := s.DialContext(context.Background(), "tcp", "x.private:80")
+			errCh <- err
+		}()
 
-	err := <-errCh
-	if err == nil {
-		t.Fatal("Dial succeeded on drained conn")
-	}
-	if !errors.Is(err, syscall.ECONNREFUSED) {
-		t.Fatalf("error = %v, want ECONNREFUSED", err)
-	}
+		synctest.Wait()
+		select {
+		case err := <-errCh:
+			t.Fatalf("Dial returned before timeout: %v", err)
+		default:
+		}
+
+		time.Sleep(200 * time.Millisecond)
+		synctest.Wait()
+
+		err := <-errCh
+		if err == nil {
+			t.Fatal("Dial succeeded on drained conn")
+		}
+		if !errors.Is(err, syscall.ECONNREFUSED) {
+			t.Fatalf("error = %v, want ECONNREFUSED", err)
+		}
+	})
 }
 
 func TestAcceptStreamSerializesWithDrain(t *testing.T) {
@@ -443,15 +447,65 @@ func TestSessionConnDialRefusesAfterClose(t *testing.T) {
 	}
 }
 
+// blockingTransport blocks RoundTrip until the request context is cancelled,
+// modeling a conn whose peer has silently gone away.
+type blockingTransport struct{}
+
+func (blockingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	var dreq pbpd.DialReq
+	if err := protodelim.UnmarshalFrom(bufio.NewReader(req.Body), &dreq); err != nil {
+		return nil, err
+	}
+	<-req.Context().Done()
+	return nil, req.Context().Err()
+}
+
+func (blockingTransport) CloseIdleConnections() {}
+
+func TestDialBudgetBoundsHangingRoundTrip(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		h := newFakeConn("conn-1")
+		h.transport = blockingTransport{}
+		h.authToken = "tok"
+
+		s := newBareDialerForTest(h, 80*time.Millisecond)
+		defer s.Close() //nolint:errcheck
+
+		errCh := make(chan error, 1)
+		go func() {
+			_, err := s.DialContext(context.Background(), "tcp", "x.private:80")
+			errCh <- err
+		}()
+
+		synctest.Wait()
+		select {
+		case err := <-errCh:
+			t.Fatalf("Dial returned before timeout: %v", err)
+		default:
+		}
+
+		time.Sleep(80 * time.Millisecond)
+		synctest.Wait()
+
+		err := <-errCh
+		if err == nil {
+			t.Fatal("Dial succeeded on hanging conn, want timeout")
+		}
+		if !errors.Is(err, syscall.ECONNREFUSED) {
+			t.Fatalf("error = %v, want ECONNREFUSED", err)
+		}
+	})
+}
+
 func TestParkDrainingNoOpAfterClose(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	s := &Dialer{
-		ctx:         ctx,
-		cancel:      cancel,
-		ready:       make(chan struct{}),
-		dialWait:    50 * time.Millisecond,
-		openFn:      func(context.Context) (*sessionConn, error) { return nil, errors.New("never") },
-		done:        make(chan struct{}),
+		ctx:      ctx,
+		cancel:   cancel,
+		ready:    make(chan struct{}),
+		dialWait: 50 * time.Millisecond,
+		openFn:   func(context.Context) (*sessionConn, error) { return nil, errors.New("never") },
+		done:     make(chan struct{}),
 	}
 	cancel()
 
@@ -520,44 +574,29 @@ func TestCloseStopsSupervisorAndConns(t *testing.T) {
 }
 
 func TestDialContextCancelDuringWait(t *testing.T) {
-	first := newFakeConn("conn-1")
-	transient := errors.New("transient")
-	var calls atomic.Int32
-	openFn := func(context.Context) (*sessionConn, error) {
-		i := calls.Add(1)
-		if i == 1 {
-			return first, nil
+	synctest.Test(t, func(t *testing.T) {
+		s := newBareDialerForTest(nil, 5*time.Second)
+		defer s.Close() //nolint:errcheck
+
+		ctx, cancel := context.WithCancel(context.Background())
+		errCh := make(chan error, 1)
+		go func() {
+			_, err := s.DialContext(ctx, "tcp", "x.private:80")
+			errCh <- err
+		}()
+
+		synctest.Wait()
+		cancel()
+		synctest.Wait()
+
+		err := <-errCh
+		if err == nil {
+			t.Fatal("Dial succeeded, want context cancel")
 		}
-		return nil, transient
-	}
-	s, clk := newTestSessionWithClock(t, openFn)
-	s.dialWait = 5 * time.Second
-
-	first.serverErrCh <- errors.New("boom")
-	waitFor(t, time.Second, func() bool {
-		cur, _, _ := s.snapshot()
-		return cur == nil
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("error = %v, want context.Canceled", err)
+		}
 	})
-
-	ctx, cancel := context.WithCancel(context.Background())
-	var (
-		wg  sync.WaitGroup
-		err error
-	)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		_, err = s.DialContext(ctx, "tcp", "x.private:80")
-	}()
-	waitFor(t, time.Second, func() bool { return clk.NumWaiters() >= 2 })
-	cancel()
-	wg.Wait()
-	if err == nil {
-		t.Fatal("Dial succeeded, want context cancel")
-	}
-	if !errors.Is(err, context.Canceled) {
-		t.Fatalf("error = %v, want context.Canceled", err)
-	}
 }
 
 func TestReadControlHandlesPleaseDrain(t *testing.T) {


### PR DESCRIPTION
Fixes https://linear.app/ngrok/issue/GAT-338.

- bound each Session.dial by the dial-wait budget so a dial onto a silently-dead conn fails fast
- lower the HTTP/2 keepalive/PingTimeout