### PR TITLE
Pin github action dependencies to sha commits

### DIFF
--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -10,9 +10,9 @@ jobs:
     env:
       NGROK_TEST_FLAKEY: 1
     steps:
-    - uses: actions/checkout@v4
-    - uses: cachix/install-nix-action@v27
-    - uses: HatsuneMiku3939/direnv-action@v1
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+    - uses: cachix/install-nix-action@ba0dd844c9180cbf77aa72a116d6fbc515d0e87b # v27
+    - uses: HatsuneMiku3939/direnv-action@fe6ca688de409566c44001c1e65ad6925f0e9cbb # v1
     - name: direnv allow
       run: direnv allow .
     - name: go mod tidy
@@ -36,9 +36,9 @@ jobs:
       NGROK_TEST_FLAKEY: 1
       NGROK_AUTHTOKEN: ${{ secrets.NGROK_AUTHTOKEN }}
     steps:
-    - uses: actions/checkout@v4
-    - uses: cachix/install-nix-action@v27
-    - uses: HatsuneMiku3939/direnv-action@v1
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+    - uses: cachix/install-nix-action@ba0dd844c9180cbf77aa72a116d6fbc515d0e87b # v27
+    - uses: HatsuneMiku3939/direnv-action@fe6ca688de409566c44001c1e65ad6925f0e9cbb # v1
     - name: direnv allow
       run: direnv allow .
     - name: Test

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,11 +13,11 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 2
-      - uses: cachix/install-nix-action@v27
-      - uses: HatsuneMiku3939/direnv-action@v1
+      - uses: cachix/install-nix-action@ba0dd844c9180cbf77aa72a116d6fbc515d0e87b # v27
+      - uses: HatsuneMiku3939/direnv-action@fe6ca688de409566c44001c1e65ad6925f0e9cbb # v1
       - name: direnv allow
         run: direnv allow .
       - name: Run goimports


### PR DESCRIPTION
Git tags are mutable, so security best-practice for actions is to pin to shas instead.