### PR TITLE
privatedial: fall back to HTTP/2 when QUIC can't get adequate UDP buffers

### DIFF
--- a/privatedial/client.go
+++ b/privatedial/client.go
@@ -90,6 +90,27 @@ var errDialWaitTimeout = errors.New("private-dial: dial wait timeout")
 // it and skips the happy-eyeballs race entirely.
 var stickyProtocol atomic.Pointer[Protocol]
 
+// probeBuffers reports whether a QUIC socket could obtain the UDP buffer sizes
+// quic-go wants; a non-nil error means it could not and HTTP/2 should be forced
+// instead of racing. It is a var so tests can drive a deterministic outcome
+// regardless of the host kernel's buffer tuning.
+var probeBuffers = probeQUICBuffers
+
+// The buffer-probe outcome is a host/kernel property — identical for every
+// Dialer in the process — so it is memoized here, lazily and exactly once.
+var (
+	probeOnce sync.Once
+	probeErr  error
+)
+
+// quicBuffersUsable runs the UDP-buffer probe at most once per process and
+// returns its (cached) result. A non-nil error means a QUIC connection would be
+// degraded, so the caller should force HTTP/2.
+func quicBuffersUsable() error {
+	probeOnce.Do(func() { probeErr = probeBuffers() })
+	return probeErr
+}
+
 // roundTripCloser is the subset of transport behavior the session relies on.
 // Holding the transport behind this interface lets a single Dialer
 // implementation drive either protocol.
@@ -260,6 +281,11 @@ func (d *Dialer) open(ctx context.Context) (*sessionConn, Protocol, error) {
 		if stickyProto != nil {
 			proto = *stickyProto
 			d.log.Debug("reusing protocol from earlier race", "protocol", proto)
+		} else if err := quicBuffersUsable(); err != nil {
+			// Force H2 if quic buffers are small.
+			// See https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes
+			proto = ProtocolH2
+			d.log.Debug("UDP buffer probe failed, forcing HTTP/2", "error", err)
 		}
 	}
 	switch proto {

--- a/privatedial/client_integration_test.go
+++ b/privatedial/client_integration_test.go
@@ -16,6 +16,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"syscall"
 	"testing"
@@ -40,9 +41,15 @@ import (
 // between cases and must not run in parallel.
 
 // resetSticky clears the process-global protocol decision so each test
-// starts from ProtocolAuto.
+// starts from ProtocolAuto. It also resets the memoized UDP-buffer probe and
+// forces it to succeed so the race runs regardless of the host kernel's buffer
+// tuning; tests that want to exercise the probe-driven HTTP/2 fallback override
+// probeBuffers after calling this.
 func resetSticky() {
 	stickyProtocol.Store(nil)
+	probeBuffers = func() error { return nil }
+	probeOnce = sync.Once{}
+	probeErr = nil
 }
 
 func TestRaceQUICWins(t *testing.T) {
@@ -101,6 +108,63 @@ func TestRaceFallsBackToH2(t *testing.T) {
 	// session can't have come up before quicHeadStart elapsed.
 	if elapsed := time.Since(start); elapsed < quicHeadStart {
 		t.Fatalf("fallback completed in %v, expected at least the %v head start", elapsed, quicHeadStart)
+	}
+}
+
+func TestBufferProbeForcesH2(t *testing.T) {
+	resetSticky()
+	// Simulate a host where QUIC can't obtain the UDP buffer sizes it wants.
+	// The probe should short-circuit the race and force HTTP/2 without ever
+	// touching QUIC.
+	probeBuffers = func() error { return errors.New("failed to increase receive buffer size") }
+
+	cert := genTLSCert(t)
+	var quicHits, h2Hits atomic.Int64
+	quicAddr := startH3Server(t, cert, privateDialHandler(&quicHits))
+	h2Addr := startH2Server(t, cert, privateDialHandler(&h2Hits))
+
+	sess := mustConnect(t, Config{
+		QUICServerAddr: quicAddr,
+		H2ServerAddr:   h2Addr,
+		AuthToken:      "test-token",
+		TLSConfig:      &tls.Config{InsecureSkipVerify: true},
+	})
+	defer sess.Close()
+
+	if got := sess.Protocol(); got != ProtocolH2 {
+		t.Fatalf("expected the buffer probe to force HTTP/2, Protocol = %v", got)
+	}
+	// The probe is decoupled from stickyProtocol: it forces HTTP/2 for this
+	// dialer without writing the process-global race decision.
+	if got := stickyProtocol.Load(); got != nil {
+		t.Fatalf("buffer probe should not set sticky protocol, got %v", *got)
+	}
+	if n := quicHits.Load(); n != 0 {
+		t.Fatalf("expected QUIC to be skipped entirely, got %d hits", n)
+	}
+	if h2Hits.Load() == 0 {
+		t.Fatal("expected the HTTP/2 server to receive the /session request")
+	}
+}
+
+func TestBufferProbeMemoized(t *testing.T) {
+	resetSticky()
+	// The probe answer is a host property, so it must run at most once per
+	// process regardless of how many connects (or Dialers) consult it. This is
+	// memoized independently of stickyProtocol so it survives changes to where
+	// the protocol decision is cached.
+	var calls atomic.Int64
+	probeBuffers = func() error {
+		calls.Add(1)
+		return errors.New("probe failed")
+	}
+	for range 3 {
+		if err := quicBuffersUsable(); err == nil {
+			t.Fatal("expected the memoized probe to keep returning its error")
+		}
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("probe should run exactly once, ran %d times", got)
 	}
 }
 

--- a/privatedial/go.mod
+++ b/privatedial/go.mod
@@ -5,12 +5,12 @@ go 1.26.0
 require (
 	github.com/quic-go/quic-go v0.59.1
 	golang.org/x/net v0.55.0
+	golang.org/x/sys v0.45.0
 	google.golang.org/protobuf v1.36.11
 )
 
 require (
 	github.com/quic-go/qpack v0.6.0 // indirect
 	golang.org/x/crypto v0.51.0 // indirect
-	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 )

--- a/privatedial/udpbuffer_linux.go
+++ b/privatedial/udpbuffer_linux.go
@@ -1,0 +1,35 @@
+//go:build linux
+
+package privatedial
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// forceSetReceiveUDPBuffer / forceSetSendUDPBuffer are ported from quic-go's
+// forceSetReceiveBuffer / forceSetSendBuffer (sys_conn_helper_linux.go, as of
+// github.com/quic-go/quic-go v0.59.1, MIT-licensed — see udpbuffer_unix.go for
+// the attribution): on Linux a process with CAP_NET_ADMIN can exceed
+// net.core.{r,w}mem_max via SO_{RCV,SND}BUFFORCE.
+
+func forceSetReceiveUDPBuffer(sc syscall.RawConn, bytes int) error {
+	var serr error
+	if err := sc.Control(func(fd uintptr) {
+		serr = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_RCVBUFFORCE, bytes)
+	}); err != nil {
+		return err
+	}
+	return serr
+}
+
+func forceSetSendUDPBuffer(sc syscall.RawConn, bytes int) error {
+	var serr error
+	if err := sc.Control(func(fd uintptr) {
+		serr = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_SNDBUFFORCE, bytes)
+	}); err != nil {
+		return err
+	}
+	return serr
+}

--- a/privatedial/udpbuffer_other.go
+++ b/privatedial/udpbuffer_other.go
@@ -1,0 +1,8 @@
+//go:build !(linux || darwin || freebsd)
+
+package privatedial
+
+// probeQUICBuffers is a no-op on platforms where we don't inspect UDP socket
+// buffer sizes. It reports success so protocol selection behaves as it did
+// before the probe was added (QUIC is raced normally).
+func probeQUICBuffers() error { return nil }

--- a/privatedial/udpbuffer_unix.go
+++ b/privatedial/udpbuffer_unix.go
@@ -1,0 +1,108 @@
+//go:build linux || darwin || freebsd
+
+// The UDP-buffer probe in this file is adapted from quic-go's
+// setReceiveBuffer / setSendBuffer (sys_conn_buffers.go,
+// sys_conn_buffers_write.go) and inspectReadBuffer / inspectWriteBuffer
+// (sys_conn_oob.go), as of github.com/quic-go/quic-go v0.59.1. We can't call
+// those functions because they're unexported, so the inspect/grow/force
+// algorithm and the error-message strings are reproduced here. quic-go is
+// MIT-licensed:
+//
+//	Copyright (c) 2016 the quic-go authors & Google, Inc.
+//
+// See the full license at https://github.com/quic-go/quic-go/blob/master/LICENSE.md.
+
+package privatedial
+
+import (
+	"fmt"
+	"net"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// desiredUDPBufferSize mirrors quic-go's protocol.DesiredReceiveBufferSize and
+// protocol.DesiredSendBufferSize (7 MiB). quic-go tries to grow a QUIC socket's
+// kernel receive and send buffers to this size and logs a warning if it can't;
+// a connection with smaller buffers is degraded. We probe for the same
+// condition before racing so we can quietly fall back to HTTP/2 instead.
+const desiredUDPBufferSize = (1 << 20) * 7
+
+// probeQUICBuffers opens a throwaway UDP socket and replicates quic-go's
+// setReceiveBuffer/setSendBuffer logic on it, returning the first error either
+// would report. A nil result means QUIC would get the buffer sizes it wants;
+// any error means a QUIC connection would be degraded (and quic-go would log a
+// warning), so the caller should force HTTP/2.
+func probeQUICBuffers() error {
+	pc, err := net.ListenUDP("udp", nil)
+	if err != nil {
+		return fmt.Errorf("probe udp socket: %w", err)
+	}
+	defer pc.Close()
+
+	sc, err := pc.SyscallConn()
+	if err != nil {
+		return fmt.Errorf("probe udp syscall conn: %w", err)
+	}
+
+	if err := checkUDPBuffer(sc, pc.SetReadBuffer, unix.SO_RCVBUF, forceSetReceiveUDPBuffer, "receive"); err != nil {
+		return err
+	}
+	return checkUDPBuffer(sc, pc.SetWriteBuffer, unix.SO_SNDBUF, forceSetSendUDPBuffer, "send")
+}
+
+// checkUDPBuffer mirrors quic-go's setReceiveBuffer/setSendBuffer for a single
+// buffer: inspect the current size, try to grow it to the desired size (with a
+// privileged force attempt as a fallback, on platforms that support it), and
+// report whether the desired size was reached.
+func checkUDPBuffer(
+	sc syscall.RawConn,
+	set func(int) error,
+	inspectOpt int,
+	force func(syscall.RawConn, int) error,
+	kind string,
+) error {
+	size, err := inspectUDPBuffer(sc, inspectOpt)
+	if err != nil {
+		return fmt.Errorf("failed to determine %s buffer size: %w", kind, err)
+	}
+	if size >= desiredUDPBufferSize {
+		return nil
+	}
+	// Ignore the error. We check if we succeeded by querying the buffer size afterward.
+	_ = set(desiredUDPBufferSize)
+	newSize, err := inspectUDPBuffer(sc, inspectOpt)
+	if newSize < desiredUDPBufferSize {
+		// Try again with the privileged force option (a no-op where unsupported).
+		_ = force(sc, desiredUDPBufferSize)
+		newSize, err = inspectUDPBuffer(sc, inspectOpt)
+		if err != nil {
+			return fmt.Errorf("failed to determine %s buffer size: %w", kind, err)
+		}
+	}
+	if err != nil {
+		return fmt.Errorf("failed to determine %s buffer size: %w", kind, err)
+	}
+	if newSize == size {
+		return fmt.Errorf("failed to increase %s buffer size (wanted: %d kiB, got %d kiB)", kind, desiredUDPBufferSize/1024, newSize/1024)
+	}
+	if newSize < desiredUDPBufferSize {
+		return fmt.Errorf("failed to sufficiently increase %s buffer size (was: %d kiB, wanted: %d kiB, got: %d kiB)", kind, size/1024, desiredUDPBufferSize/1024, newSize/1024)
+	}
+	return nil
+}
+
+// inspectUDPBuffer reads the current size of the socket buffer named by opt
+// (unix.SO_RCVBUF or unix.SO_SNDBUF), mirroring quic-go's inspectReadBuffer /
+// inspectWriteBuffer.
+func inspectUDPBuffer(sc syscall.RawConn, opt int) (int, error) {
+	var size int
+	var serr error
+	if err := sc.Control(func(fd uintptr) {
+		size, serr = unix.GetsockoptInt(int(fd), unix.SOL_SOCKET, opt)
+	}); err != nil {
+		return 0, err
+	}
+	return size, serr
+}

--- a/privatedial/udpbuffer_unixnoforce.go
+++ b/privatedial/udpbuffer_unixnoforce.go
@@ -1,0 +1,12 @@
+//go:build darwin || freebsd
+
+package privatedial
+
+import "syscall"
+
+// On non-Linux unix platforms there is no privileged "force" option to exceed
+// the kernel's buffer-size limit, matching quic-go's non-Linux
+// forceSetReceiveBuffer / forceSetSendBuffer no-ops.
+
+func forceSetReceiveUDPBuffer(syscall.RawConn, int) error { return nil }
+func forceSetSendUDPBuffer(syscall.RawConn, int) error    { return nil }


### PR DESCRIPTION
See https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes

Basically, there's known system configurations where quic is likely to be slower than tcp for large transfers, and in those cases it's probably best for us to default to tcp.

A user can force quic or h2 specifically if they know it's better for their environment, but for the default option I think this makes sense!

