### PR TITLE
privatedial: eagerly surface endpoint errors, and expose EndpointID

### DIFF
--- a/privatedial/client.go
+++ b/privatedial/client.go
@@ -856,14 +856,18 @@ func (d *Dialer) Err() error {
 //
 //	conn, err := dialer.DialContext(ctx, "tcp", "foo.internal:80")
 //
-// The returned net.Conn is a bidirectional byte stream.
+// The returned net.Conn is a bidirectional byte stream. It is also a
+// privatedial.Conn, so it can be type-asserted to read the resolved endpoint
+// ID the server reported (conn.(privatedial.Conn).EndpointID()).
 //
-// The server commits to the stream before it knows the dial outcome, so a
-// server-side dial failure is reported via HTTP trailers and surfaces on the
-// first Read of the returned conn (in place of io.EOF) rather than from
-// DialContext itself. That error is a *net.OpError wrapping a
+// A dial failure the server detects before bridging the stream (auth,
+// endpoint-not-found, draining) is reported via HTTP trailers and surfaces
+// from DialContext itself, since the success-signalling DialResp frame is read
+// synchronously here. A failure that occurs after the stream is established
+// (mid-stream) instead surfaces on the first failing Read (in place of
+// io.EOF). In both cases the error is a *net.OpError wrapping a
 // privatedial.Error, and — for error codes with a net analogue — also wrapping
-// a standard sentinel so callers can branch with errors.Is/As as before:
+// a standard sentinel so callers can branch with errors.Is/As:
 //   - an unauthorized or "session draining" rejection wraps
 //     syscall.ECONNREFUSED — analogous to a refused TCP connect.
 //   - other codes carry no sentinel; recover the ngrok code with
@@ -1322,11 +1326,39 @@ func (h *sessionConn) dial(ctx context.Context, addr dialAddr) (net.Conn, error)
 		}
 	}
 
+	// On success the server writes a length-prefixed DialResp as the first
+	// body frame, carrying the resolved endpoint ID; the rest of the stream
+	// is then raw bytes. We must consume that frame here so it doesn't corrupt
+	// the byte stream the caller reads. A failure detected before the stream
+	// is bridged (auth, endpoint-not-found, draining) instead leaves the body
+	// empty and reports the error via trailers, which become readable once the
+	// body hits EOF. So if we can't read a DialResp, consult the trailers and
+	// surface the server's structured error from the dial itself — mirroring
+	// how the /session handshake surfaces SessionAck failures from Connect.
+	// Errors that occur after a successful DialResp (mid-stream) still ride out
+	// on the trailers and surface on the first failing Read.
+	respBody := newReadCloseByteReader(resp.Body)
+	dresp := new(pbpd.DialResp)
+	if err := protodelimUnmarshaler.UnmarshalFrom(respBody, dresp); err != nil {
+		_ = resp.Body.Close()
+		_ = reqWriter.Close()
+		reqCancel()
+		if rerr := errorFromTrailer(resp.Trailer); rerr != nil {
+			// Wrap as *net.OpError so the failure category bubbles via
+			// errors.Is/errors.As, matching dialConn.Read's trailer path.
+			return nil, &net.OpError{Op: "dial", Net: addr.Network(), Addr: addr, Err: rerr}
+		}
+		se := newStaleConnError(addr)
+		se.wrapped = fmt.Errorf("read DialResp: %w", err)
+		return nil, se
+	}
+
 	return &dialConn{
 		remoteAddr: addr,
+		endpointID: dresp.GetEndpointId(),
 		reqBody:    reqWriter,
 		resp:       resp,
-		respBody:   resp.Body,
+		respBody:   respBody,
 		reqCancel:  reqCancel,
 	}, nil
 }
@@ -1639,25 +1671,49 @@ func (h *sessionConn) readControl() {
 	}
 }
 
+// Conn is the concrete type of the net.Conn returned from
+// Dialer.DialContext. Callers can type-assert to it to read private-dial
+// metadata about the established stream, e.g.:
+//
+//	conn, err := dialer.DialContext(ctx, "tcp", "foo.private:80")
+//	if pc, ok := conn.(privatedial.Conn); ok {
+//		log.Printf("connected to endpoint %s", pc.EndpointID())
+//	}
+type Conn interface {
+	net.Conn
+	// EndpointID returns the ngrok endpoint ID (e.g. "ep_...") the dial
+	// resolved to, as reported by the server in the DialResp frame. It is
+	// empty when the server did not report one.
+	EndpointID() string
+}
+
 // dialConn is the net.Conn returned from Dialer.DialContext. Read pulls
 // from the response body; Write pushes into the request body. Close terminates
 // both sides.
 //
-// Because the server commits to a 200 before it knows whether the dial will
-// succeed, dial failures are reported via HTTP trailers that only become
-// readable once the response body reaches EOF. Read therefore inspects the
-// trailers on EOF: a server-reported failure surfaces as a privatedial.Error
-// in place of io.EOF, while a clean stream termination surfaces as io.EOF.
+// The DialResp success frame is consumed in dial before the conn is returned,
+// so pre-bridge failures surface from DialContext (see Dialer.DialContext). A
+// failure that occurs mid-stream is reported via HTTP trailers that only
+// become readable once the response body reaches EOF. Read therefore inspects
+// the trailers on EOF: a server-reported failure surfaces as a
+// privatedial.Error in place of io.EOF, while a clean stream termination
+// surfaces as io.EOF.
 type dialConn struct {
-	reqBody   *io.PipeWriter
-	resp      *http.Response
-	respBody  io.ReadCloser
-	reqCancel context.CancelFunc
+	reqBody    *io.PipeWriter
+	resp       *http.Response
+	respBody   io.ReadCloser
+	reqCancel  context.CancelFunc
+	endpointID string
 
 	remoteAddr dialAddr
 
 	closeOnce sync.Once
 }
+
+// EndpointID returns the resolved ngrok endpoint ID reported by the server.
+func (c *dialConn) EndpointID() string { return c.endpointID }
+
+var _ Conn = (*dialConn)(nil)
 
 func (c *dialConn) Read(p []byte) (int, error) {
 	n, err := c.respBody.Read(p)

--- a/privatedial/client_integration_test.go
+++ b/privatedial/client_integration_test.go
@@ -236,6 +236,13 @@ func TestDialEcho(t *testing.T) {
 			}
 			defer conn.Close()
 
+			// The server reports the resolved endpoint ID in the DialResp frame.
+			if pc, ok := conn.(Conn); !ok {
+				t.Fatalf("conn %T does not implement privatedial.Conn", conn)
+			} else if pc.EndpointID() != "ep_test" {
+				t.Fatalf("EndpointID() = %q, want %q", pc.EndpointID(), "ep_test")
+			}
+
 			payload := []byte("hello private dial over " + tc.name)
 			if _, err := conn.Write(payload); err != nil {
 				t.Fatalf("Write: %v", err)
@@ -256,10 +263,11 @@ func TestDialEcho(t *testing.T) {
 	}
 }
 
-// TestDialTrailerError proves an end-to-end dial failure reported via HTTP
-// trailers is rehydrated into a privatedial.Error and surfaced on the first
-// Read of the returned conn (the server commits to a 200 before it knows the
-// dial outcome, so the error can only ride out on the trailers).
+// TestDialTrailerError proves an end-to-end pre-bridge dial failure reported
+// via HTTP trailers is rehydrated into a privatedial.Error and surfaced from
+// DialContext itself: the server commits a 200 with no DialResp frame and an
+// empty body, so reading the (absent) success frame fails and the client
+// consults the trailers before returning the conn.
 func TestDialTrailerError(t *testing.T) {
 	cert := genTLSCert(t)
 
@@ -283,8 +291,9 @@ func TestDialTrailerError(t *testing.T) {
 				http.Error(w, "bad DialReq", http.StatusBadRequest)
 				return
 			}
-			// Commit to a 200, then report the dial failure via trailers
-			// with no body, mirroring an immediate server-side failure.
+			// Commit to a 200, then report the dial failure via trailers with
+			// no DialResp and no body, mirroring an immediate server-side
+			// failure (e.g. endpoint not found).
 			w.Header().Set(http.TrailerPrefix+dialErrorCodeTrailer, errCodeSessionDraining)
 			w.Header().Set(http.TrailerPrefix+dialErrorMessageTrailer, "session draining")
 			w.WriteHeader(http.StatusOK)
@@ -305,31 +314,104 @@ func TestDialTrailerError(t *testing.T) {
 			sess := mustConnect(t, configForProtocol(t, tc.proto, cert, dialErrorHandler()))
 			defer sess.Close()
 
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			_, err := sess.DialContext(ctx, "tcp", "foo.private:80")
+			if err == nil {
+				t.Fatal("DialContext succeeded, want trailer error")
+			}
+			assertDialTrailerError(t, err)
+		})
+	}
+}
+
+// TestDialMidStreamTrailerError proves a failure that occurs after the stream
+// is established (a successful DialResp, then bytes, then an error trailer)
+// surfaces on the first failing Read rather than from DialContext.
+func TestDialMidStreamTrailerError(t *testing.T) {
+	cert := genTLSCert(t)
+
+	midStreamErrorHandler := func() http.Handler {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/session", func(w http.ResponseWriter, r *http.Request) {
+			var req pbpd.SessionReq
+			if err := protodelimUnmarshaler.UnmarshalFrom(bufio.NewReader(r.Body), &req); err != nil {
+				http.Error(w, "bad SessionReq", http.StatusBadRequest)
+				return
+			}
+			if _, err := protodelim.MarshalTo(w, &pbpd.SessionAck{ServerId: "midstream-srv"}); err != nil {
+				return
+			}
+			flush(w)
+			<-r.Context().Done()
+		})
+		mux.HandleFunc("/dial", func(w http.ResponseWriter, r *http.Request) {
+			var dreq pbpd.DialReq
+			if err := protodelimUnmarshaler.UnmarshalFrom(bufio.NewReader(r.Body), &dreq); err != nil {
+				http.Error(w, "bad DialReq", http.StatusBadRequest)
+				return
+			}
+			// Succeed (DialResp + some bytes), then fail via trailers.
+			w.Header().Set(http.TrailerPrefix+dialErrorCodeTrailer, errCodeSessionDraining)
+			w.Header().Set(http.TrailerPrefix+dialErrorMessageTrailer, "session draining")
+			w.WriteHeader(http.StatusOK)
+			if _, err := protodelim.MarshalTo(w, &pbpd.DialResp{EndpointId: "ep_test"}); err != nil {
+				return
+			}
+			_, _ = w.Write([]byte("partial"))
+			flush(w)
+		})
+		return mux
+	}
+
+	for _, tc := range []struct {
+		name  string
+		proto Protocol
+	}{
+		{"h2", ProtocolH2},
+		{"quic", ProtocolQUIC},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resetSticky()
+			sess := mustConnect(t, configForProtocol(t, tc.proto, cert, midStreamErrorHandler()))
+			defer sess.Close()
+
+			// The dial itself succeeds — the error only appears once the stream ends.
 			conn := mustDial(t, sess, "foo.private:80")
 			defer conn.Close()
 
-			_, err := io.ReadAll(conn)
+			got, err := io.ReadAll(conn)
+			if string(got) != "partial" {
+				t.Fatalf("read %q, want the pre-error bytes %q", got, "partial")
+			}
 			if err == nil {
 				t.Fatal("Read succeeded, want trailer error")
 			}
 			if errors.Is(err, io.EOF) {
 				t.Fatalf("Read returned io.EOF, want trailer error")
 			}
-			var nerr Error
-			if !errors.As(err, &nerr) {
-				t.Fatalf("error %T not assignable to privatedial.Error", err)
-			}
-			if nerr.Code() != errCodeSessionDraining {
-				t.Fatalf("Code() = %q, want %q", nerr.Code(), errCodeSessionDraining)
-			}
-			if !strings.Contains(nerr.Error(), "session draining") {
-				t.Fatalf("Error() = %q, want to contain message", nerr.Error())
-			}
-			// The code's net sentinel must bubble end-to-end.
-			if !errors.Is(err, syscall.ECONNREFUSED) {
-				t.Fatalf("want ECONNREFUSED to bubble, got %v", err)
-			}
+			assertDialTrailerError(t, err)
 		})
+	}
+}
+
+// assertDialTrailerError checks that err is the rehydrated session-draining
+// trailer error, carrying its ngrok code, message, and net sentinel.
+func assertDialTrailerError(t *testing.T, err error) {
+	t.Helper()
+	var nerr Error
+	if !errors.As(err, &nerr) {
+		t.Fatalf("error %T not assignable to privatedial.Error", err)
+	}
+	if nerr.Code() != errCodeSessionDraining {
+		t.Fatalf("Code() = %q, want %q", nerr.Code(), errCodeSessionDraining)
+	}
+	if !strings.Contains(nerr.Error(), "session draining") {
+		t.Fatalf("Error() = %q, want to contain message", nerr.Error())
+	}
+	// The code's net sentinel must bubble end-to-end.
+	if !errors.Is(err, syscall.ECONNREFUSED) {
+		t.Fatalf("want ECONNREFUSED to bubble, got %v", err)
 	}
 }
 
@@ -620,6 +702,10 @@ func privateDialHandler(counter *atomic.Int64) http.Handler {
 			return
 		}
 		w.WriteHeader(http.StatusOK)
+		// The success frame precedes the raw stream.
+		if _, err := protodelim.MarshalTo(w, &pbpd.DialResp{EndpointId: "ep_test"}); err != nil {
+			return
+		}
 		flush(w)
 		// The stream is now raw TCP: echo everything the client sends.
 		// br may hold bytes already read past the DialReq, so copy from it.
@@ -637,6 +723,10 @@ func echoDialHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusOK)
+	// The success frame precedes the raw stream.
+	if _, err := protodelim.MarshalTo(w, &pbpd.DialResp{EndpointId: "ep_test"}); err != nil {
+		return
+	}
 	flush(w)
 	_, _ = io.Copy(flushWriter{w}, br)
 }

--- a/privatedial/internal/pb_private_dial/private_dial.pb.go
+++ b/privatedial/internal/pb_private_dial/private_dial.pb.go
@@ -531,6 +531,62 @@ func (x *DialReq) GetSessionReq() *SessionReq {
 	return nil
 }
 
+// DialResp is the first message the server sends on a dial stream (POST
+// /dial) body, after auth and endpoint resolution succeed and before the
+// stream becomes raw bytes. Its presence is itself the success signal; dial
+// failures are reported via DialTrailer instead.
+type DialResp struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	EndpointId    string                 `protobuf:"bytes,1,opt,name=endpoint_id,json=endpointId,proto3" json:"endpoint_id,omitempty"`
+	Metadata      map[string]string      `protobuf:"bytes,2,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DialResp) Reset() {
+	*x = DialResp{}
+	mi := &file_lib_private_dial_private_dial_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DialResp) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DialResp) ProtoMessage() {}
+
+func (x *DialResp) ProtoReflect() protoreflect.Message {
+	mi := &file_lib_private_dial_private_dial_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DialResp.ProtoReflect.Descriptor instead.
+func (*DialResp) Descriptor() ([]byte, []int) {
+	return file_lib_private_dial_private_dial_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *DialResp) GetEndpointId() string {
+	if x != nil {
+		return x.EndpointId
+	}
+	return ""
+}
+
+func (x *DialResp) GetMetadata() map[string]string {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 // DialTrailer is sent via HTTP/2 trailers when the dial stream terminates.
 type DialTrailer struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -542,7 +598,7 @@ type DialTrailer struct {
 
 func (x *DialTrailer) Reset() {
 	*x = DialTrailer{}
-	mi := &file_lib_private_dial_private_dial_proto_msgTypes[8]
+	mi := &file_lib_private_dial_private_dial_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -554,7 +610,7 @@ func (x *DialTrailer) String() string {
 func (*DialTrailer) ProtoMessage() {}
 
 func (x *DialTrailer) ProtoReflect() protoreflect.Message {
-	mi := &file_lib_private_dial_private_dial_proto_msgTypes[8]
+	mi := &file_lib_private_dial_private_dial_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -567,7 +623,7 @@ func (x *DialTrailer) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DialTrailer.ProtoReflect.Descriptor instead.
 func (*DialTrailer) Descriptor() ([]byte, []int) {
-	return file_lib_private_dial_private_dial_proto_rawDescGZIP(), []int{8}
+	return file_lib_private_dial_private_dial_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *DialTrailer) GetErrorCode() string {
@@ -624,6 +680,13 @@ const file_lib_private_dial_private_dial_proto_rawDesc = "" +
 	"sessionReq\x1a;\n" +
 	"\rMetadataEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xaa\x01\n" +
+	"\bDialResp\x12\x1f\n" +
+	"\vendpoint_id\x18\x01 \x01(\tR\n" +
+	"endpointId\x12@\n" +
+	"\bmetadata\x18\x02 \x03(\v2$.private_dial.DialResp.MetadataEntryR\bmetadata\x1a;\n" +
+	"\rMetadataEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"Q\n" +
 	"\vDialTrailer\x12\x1d\n" +
 	"\n" +
@@ -642,7 +705,7 @@ func file_lib_private_dial_private_dial_proto_rawDescGZIP() []byte {
 	return file_lib_private_dial_private_dial_proto_rawDescData
 }
 
-var file_lib_private_dial_private_dial_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
+var file_lib_private_dial_private_dial_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
 var file_lib_private_dial_private_dial_proto_goTypes = []any{
 	(*SessionReq)(nil),          // 0: private_dial.SessionReq
 	(*SessionAck)(nil),          // 1: private_dial.SessionAck
@@ -652,25 +715,28 @@ var file_lib_private_dial_private_dial_proto_goTypes = []any{
 	(*SessionError)(nil),        // 5: private_dial.SessionError
 	(*ControlFrame)(nil),        // 6: private_dial.ControlFrame
 	(*DialReq)(nil),             // 7: private_dial.DialReq
-	(*DialTrailer)(nil),         // 8: private_dial.DialTrailer
-	nil,                         // 9: private_dial.SessionReq.MetadataEntry
-	nil,                         // 10: private_dial.DialReq.MetadataEntry
-	(*durationpb.Duration)(nil), // 11: google.protobuf.Duration
+	(*DialResp)(nil),            // 8: private_dial.DialResp
+	(*DialTrailer)(nil),         // 9: private_dial.DialTrailer
+	nil,                         // 10: private_dial.SessionReq.MetadataEntry
+	nil,                         // 11: private_dial.DialReq.MetadataEntry
+	nil,                         // 12: private_dial.DialResp.MetadataEntry
+	(*durationpb.Duration)(nil), // 13: google.protobuf.Duration
 }
 var file_lib_private_dial_private_dial_proto_depIdxs = []int32{
-	9,  // 0: private_dial.SessionReq.metadata:type_name -> private_dial.SessionReq.MetadataEntry
-	11, // 1: private_dial.SessionAck.ping_interval:type_name -> google.protobuf.Duration
+	10, // 0: private_dial.SessionReq.metadata:type_name -> private_dial.SessionReq.MetadataEntry
+	13, // 1: private_dial.SessionAck.ping_interval:type_name -> google.protobuf.Duration
 	2,  // 2: private_dial.ControlFrame.ping:type_name -> private_dial.Ping
 	4,  // 3: private_dial.ControlFrame.please_drain:type_name -> private_dial.PleaseDrain
 	5,  // 4: private_dial.ControlFrame.session_error:type_name -> private_dial.SessionError
 	3,  // 5: private_dial.ControlFrame.pong:type_name -> private_dial.Pong
-	10, // 6: private_dial.DialReq.metadata:type_name -> private_dial.DialReq.MetadataEntry
+	11, // 6: private_dial.DialReq.metadata:type_name -> private_dial.DialReq.MetadataEntry
 	0,  // 7: private_dial.DialReq.session_req:type_name -> private_dial.SessionReq
-	8,  // [8:8] is the sub-list for method output_type
-	8,  // [8:8] is the sub-list for method input_type
-	8,  // [8:8] is the sub-list for extension type_name
-	8,  // [8:8] is the sub-list for extension extendee
-	0,  // [0:8] is the sub-list for field type_name
+	12, // 8: private_dial.DialResp.metadata:type_name -> private_dial.DialResp.MetadataEntry
+	9,  // [9:9] is the sub-list for method output_type
+	9,  // [9:9] is the sub-list for method input_type
+	9,  // [9:9] is the sub-list for extension type_name
+	9,  // [9:9] is the sub-list for extension extendee
+	0,  // [0:9] is the sub-list for field type_name
 }
 
 func init() { file_lib_private_dial_private_dial_proto_init() }
@@ -690,7 +756,7 @@ func file_lib_private_dial_private_dial_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_lib_private_dial_private_dial_proto_rawDesc), len(file_lib_private_dial_private_dial_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   11,
+			NumMessages:   13,
 			NumExtensions: 0,
 			NumServices:   0,
 		},


### PR DESCRIPTION
Before this change, it was difficult to correctly identify some errors, and there was no way to get the ID of the endpoint actually dialed.

This fixes them by, per the spec, adding a `DialResp` type which always gets read immediately.

If that type isn't written on the wire, that means it's an error, and the existing trailer mechanism is used to rehydrate the error.

The use of trailers for the error, rather than putting it in DialResp, is so that we can push down an error later (i.e. "agent went away") which happened after we finished the dial, and that mechanism being common to all errors seems a little cleaner to me.

This, of course, also requires server-side changes, see the internal repo for those.