### PR TITLE
privatedial: add /get-host endpoint for DNS resolution

### DIFF
--- a/privatedial/client.go
+++ b/privatedial/client.go
@@ -9,6 +9,7 @@ package privatedial
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	cryptorand "crypto/rand"
 	"crypto/tls"
@@ -34,6 +35,7 @@ import (
 	"github.com/quic-go/quic-go/http3"
 	"golang.org/x/net/http2"
 	"google.golang.org/protobuf/encoding/protodelim"
+	"google.golang.org/protobuf/proto"
 
 	pbpd "golang.ngrok.com/ngrok/privatedial/internal/pb_private_dial"
 )
@@ -520,6 +522,7 @@ func (d *Dialer) openConn(ctx context.Context, p Protocol) (*sessionConn, error)
 
 	controlURL := &url.URL{Scheme: "https", Host: serverAddr, Path: "/session"}
 	dialURL := &url.URL{Scheme: "https", Host: serverAddr, Path: "/dial"}
+	getHostURL := &url.URL{Scheme: "https", Host: serverAddr, Path: "/get-host"}
 
 	// io.Pipe for the request body — first frame is SessionReq, then
 	// the body is reused for client-→server ControlFrames (Ping/Pong).
@@ -606,6 +609,7 @@ func (d *Dialer) openConn(ctx context.Context, p Protocol) (*sessionConn, error)
 	h.log = h.log.With("server_id", h.serverID)
 	h.pingInterval = ack.GetPingInterval().AsDuration()
 	h.dialURL = dialURL
+	h.getHostURL = getHostURL
 	h.authToken = d.cfg.AuthToken
 	h.controlResp = resp
 	h.controlRespBody = respBody
@@ -1055,6 +1059,69 @@ func (d *Dialer) dial(ctx context.Context, addr dialAddr) (net.Conn, error) {
 	}
 }
 
+// GetHost reports whether host has a private endpoint reachable by this Dialer,
+// without dialing it. It returns whether an endpoint exists, or an error. If a
+// returned error has an ngrok error code associated with it, it will be of type
+// [Error].
+func (d *Dialer) GetHost(ctx context.Context, host string) (bool, error) {
+	if err := d.ensureConnected(ctx); err != nil {
+		return false, err
+	}
+
+	budgetCtx, cancel := context.WithTimeoutCause(ctx, d.dialWaitTimeout(), errDialWaitTimeout)
+	defer cancel()
+
+	// budgetExpired bounds the retry loop: stale conns can return immediately,
+	// so the loop must check the deadline itself.
+	budgetExpired := func() bool {
+		return errors.Is(context.Cause(budgetCtx), errDialWaitTimeout)
+	}
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return false, err
+		}
+		if budgetExpired() {
+			return false, context.DeadlineExceeded
+		}
+		cur, err := d.waitForCurrent(budgetCtx)
+		if err != nil {
+			return false, err
+		}
+		resp := new(pbpd.GetHostResp)
+		err = cur.unaryRoundTrip(budgetCtx, cur.getHostURL, &pbpd.GetHostReq{Host: host}, resp)
+		if err == nil {
+			// The in-band Error reports the outcome: nil exists, the
+			// not-found code means it doesn't, anything else is a real
+			// failure surfaced as a privatedial.Error.
+			e := resp.GetError()
+			switch {
+			case e == nil:
+				return true, nil
+			case e.GetCode() == errCodeEndpointNotFound:
+				return false, nil
+			default:
+				return false, &serverError{
+					code:    e.GetCode(),
+					message: e.GetMessage(),
+					wrapped: netSentinelForCode(e.GetCode()),
+				}
+			}
+		}
+		if budgetExpired() {
+			return false, context.DeadlineExceeded
+		}
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return false, err
+		}
+		var stale *staleConnError
+		if !errors.As(err, &stale) {
+			return false, err
+		}
+		d.log.Debug("get-host raced a stale conn, retrying on a fresh one", "host", host, "error", err)
+	}
+}
+
 func (d *Dialer) waitForCurrent(ctx context.Context) (*sessionConn, error) {
 	for {
 		if err := d.ctx.Err(); err != nil {
@@ -1318,8 +1385,9 @@ type sessionConn struct {
 	lifeClosed  bool
 	lifeDrained bool
 
-	dialURL   *url.URL
-	authToken string
+	dialURL    *url.URL
+	getHostURL *url.URL
+	authToken  string
 
 	controlResp     *http.Response
 	controlRespBody *readCloseByteReader
@@ -1461,6 +1529,58 @@ func (h *sessionConn) dial(ctx context.Context, addr dialAddr) (net.Conn, error)
 	}, nil
 }
 
+// unaryRoundTrip sends req to a unary /get-* endpoint and decodes the single
+// response frame into resp. A drained/lost conn is reported as *staleConnError
+// so the caller can retry on a fresh session.
+func (h *sessionConn) unaryRoundTrip(ctx context.Context, u *url.URL, req, resp proto.Message) error {
+	var body bytes.Buffer
+	if _, err := protodelim.MarshalTo(&body, req); err != nil {
+		return fmt.Errorf("marshal %s request: %w", u.Path, err)
+	}
+
+	if !h.acceptsStreams() {
+		return &staleConnError{}
+	}
+	if reserver, ok := h.transport.(requestReserver); ok && !reserver.ReserveNewRequest() {
+		return &staleConnError{}
+	}
+
+	// The body is known up front, so a bytes.Reader avoids the writer
+	// goroutine the streaming /dial path needs. The request is bounded by ctx,
+	// so RoundTrip can run synchronously.
+	reqWithContext, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), bytes.NewReader(body.Bytes()))
+	if err != nil {
+		return fmt.Errorf("build %s request: %w", u.Path, err)
+	}
+	reqWithContext.Header.Set("Authorization", "Bearer "+h.authToken)
+	reqWithContext.Header.Set("Content-Type", "application/octet-stream")
+
+	httpResp, err := h.transport.RoundTrip(reqWithContext)
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return err
+		}
+		return &staleConnError{wrapped: err}
+	}
+	defer func() { _ = httpResp.Body.Close() }()
+
+	if httpResp.StatusCode != http.StatusOK {
+		snippet, _ := io.ReadAll(io.LimitReader(httpResp.Body, 512))
+		return fmt.Errorf("private-dial %s status %d: %s", u.Path, httpResp.StatusCode, strings.TrimSpace(string(snippet)))
+	}
+
+	respBody := newReadCloseByteReader(httpResp.Body)
+	if err := protodelimUnmarshaler.UnmarshalFrom(respBody, resp); err != nil {
+		// A 200 that then fails reports the error via trailers, readable once
+		// the body hits EOF (as with /session and /dial).
+		if rerr := errorFromTrailer(httpResp.Trailer); rerr != nil {
+			return rerr
+		}
+		return fmt.Errorf("read %s response: %w", u.Path, err)
+	}
+	return nil
+}
+
 // The HTTP trailer names a private-dial server uses to report a structured
 // ngrok error when a /dial or /session stream terminates. Because they are
 // trailers, they only become readable once the response body reaches EOF.
@@ -1536,6 +1656,11 @@ const (
 	errCodeUnauthorized    = "ERR_NGROK_709"
 	errCodeSessionDraining = "ERR_NGROK_742"
 )
+
+// errCodeEndpointNotFound is the ngrok code for a missing endpoint, reused by
+// /get-host to mean the host has no endpoint. It is the only in-band code
+// GetHost treats as "does not exist"; every other code is a real failure.
+const errCodeEndpointNotFound = "ERR_NGROK_706"
 
 // netSentinelForCode maps a private-dial ngrok error code to the net-style
 // sentinel that best matches it. The two codes with a net analogue both behave

--- a/privatedial/client_integration_test.go
+++ b/privatedial/client_integration_test.go
@@ -327,6 +327,93 @@ func TestDialEcho(t *testing.T) {
 	}
 }
 
+// TestGetHost exercises /get-host over each transport: a known host, an unknown
+// host (not-found code), a non-not-found in-band error, and a server rejection.
+func TestGetHost(t *testing.T) {
+	cert := genTLSCert(t)
+
+	getHostHandler := func() http.Handler {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/session", func(w http.ResponseWriter, r *http.Request) {
+			var req pbpd.SessionReq
+			if err := protodelimUnmarshaler.UnmarshalFrom(bufio.NewReader(r.Body), &req); err != nil {
+				http.Error(w, "bad SessionReq", http.StatusBadRequest)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			if _, err := protodelim.MarshalTo(w, &pbpd.SessionAck{ServerId: "gethost-srv"}); err != nil {
+				return
+			}
+			flush(w)
+			<-r.Context().Done()
+		})
+		mux.HandleFunc("/get-host", func(w http.ResponseWriter, r *http.Request) {
+			var req pbpd.GetHostReq
+			if err := protodelimUnmarshaler.UnmarshalFrom(bufio.NewReader(r.Body), &req); err != nil {
+				http.Error(w, "bad GetHostReq", http.StatusBadRequest)
+				return
+			}
+			if req.GetHost() == "denied.private" {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+			resp := &pbpd.GetHostResp{}
+			switch req.GetHost() {
+			case "missing.private":
+				resp.Error = &pbpd.Error{Code: errCodeEndpointNotFound, Message: "no such host"}
+			case "servfail.private":
+				// A non-not-found in-band error.
+				resp.Error = &pbpd.Error{Code: "ERR_NGROK_999", Message: "lookup failed"}
+			}
+			w.WriteHeader(http.StatusOK)
+			if _, err := protodelim.MarshalTo(w, resp); err != nil {
+				return
+			}
+			flush(w)
+		})
+		return mux
+	}
+
+	for _, tc := range []struct {
+		name  string
+		proto Protocol
+	}{
+		{"quic", ProtocolQUIC},
+		{"h2", ProtocolH2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resetSticky()
+			sess := mustConnect(t, configForProtocol(t, tc.proto, cert, getHostHandler()))
+			defer sess.Close()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			if exists, err := sess.GetHost(ctx, "foo.private"); err != nil || !exists {
+				t.Fatalf("GetHost(foo.private) = (%v, %v), want (true, nil)", exists, err)
+			}
+			if exists, err := sess.GetHost(ctx, "missing.private"); err != nil || exists {
+				t.Fatalf("GetHost(missing.private) = (%v, %v), want (false, nil)", exists, err)
+			}
+			// A non-not-found in-band error surfaces as a privatedial.Error.
+			exists, err := sess.GetHost(ctx, "servfail.private")
+			if err == nil || exists {
+				t.Fatalf("GetHost(servfail.private) = (%v, %v), want (false, non-nil)", exists, err)
+			}
+			var nerr Error
+			if !errors.As(err, &nerr) {
+				t.Fatalf("GetHost(servfail.private) error %v is not a privatedial.Error", err)
+			}
+			if nerr.Code() != "ERR_NGROK_999" {
+				t.Fatalf("GetHost(servfail.private) code = %q, want %q", nerr.Code(), "ERR_NGROK_999")
+			}
+			if exists, err := sess.GetHost(ctx, "denied.private"); err == nil || exists {
+				t.Fatalf("GetHost(denied.private) = (%v, %v), want (false, non-nil)", exists, err)
+			}
+		})
+	}
+}
+
 // TestDialTrailerError proves an end-to-end pre-bridge dial failure reported
 // via HTTP trailers is rehydrated into a privatedial.Error and surfaced from
 // DialContext itself: the server commits a 200 with no DialResp frame and an

--- a/privatedial/client_test.go
+++ b/privatedial/client_test.go
@@ -501,6 +501,42 @@ func TestDialBudgetBoundsHangingRoundTrip(t *testing.T) {
 	})
 }
 
+// reserveRefusingTransport accepts streams but never reserves a request.
+type reserveRefusingTransport struct{}
+
+func (reserveRefusingTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, errors.New("RoundTrip should not be reached")
+}
+func (reserveRefusingTransport) CloseIdleConnections()   {}
+func (reserveRefusingTransport) ReserveNewRequest() bool { return false }
+
+// TestGetHostBudgetBoundsStaleSpin proves GetHost stops at its budget instead of
+// spinning when every unaryRoundTrip returns a staleConnError.
+func TestGetHostBudgetBoundsStaleSpin(t *testing.T) {
+	h := newFakeConn("conn-1")
+	h.transport = reserveRefusingTransport{}
+	h.authToken = "tok"
+	h.getHostURL = &url.URL{Scheme: "https", Host: "fake.invalid", Path: "/get-host"}
+
+	s := newBareDialerForTest(h, 50*time.Millisecond)
+	defer s.Close() //nolint:errcheck
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := s.GetHost(context.Background(), "x.private")
+		errCh <- err
+	}()
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("GetHost succeeded on a conn that never reserves, want error")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("GetHost did not return within budget; it is spinning indefinitely")
+	}
+}
+
 func TestParkDrainingNoOpAfterClose(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	s := &Dialer{

--- a/privatedial/internal/pb_private_dial/private_dial.pb.go
+++ b/privatedial/internal/pb_private_dial/private_dial.pb.go
@@ -640,6 +640,266 @@ func (x *DialTrailer) GetErrorMessage() string {
 	return ""
 }
 
+// Error is returned in-band on the unary /get-* response messages.
+type Error struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// code is an ERR_NGROK_X error code.
+	Code string `protobuf:"bytes,1,opt,name=code,proto3" json:"code,omitempty"`
+	// message is the human readable message.
+	Message       string `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Error) Reset() {
+	*x = Error{}
+	mi := &file_lib_private_dial_private_dial_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Error) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Error) ProtoMessage() {}
+
+func (x *Error) ProtoReflect() protoreflect.Message {
+	mi := &file_lib_private_dial_private_dial_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Error.ProtoReflect.Descriptor instead.
+func (*Error) Descriptor() ([]byte, []int) {
+	return file_lib_private_dial_private_dial_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *Error) GetCode() string {
+	if x != nil {
+		return x.Code
+	}
+	return ""
+}
+
+func (x *Error) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+// GetHostReq is the request body for /get-host.
+type GetHostReq struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Host          string                 `protobuf:"bytes,1,opt,name=host,proto3" json:"host,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetHostReq) Reset() {
+	*x = GetHostReq{}
+	mi := &file_lib_private_dial_private_dial_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetHostReq) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetHostReq) ProtoMessage() {}
+
+func (x *GetHostReq) ProtoReflect() protoreflect.Message {
+	mi := &file_lib_private_dial_private_dial_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetHostReq.ProtoReflect.Descriptor instead.
+func (*GetHostReq) Descriptor() ([]byte, []int) {
+	return file_lib_private_dial_private_dial_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *GetHostReq) GetHost() string {
+	if x != nil {
+		return x.Host
+	}
+	return ""
+}
+
+// GetHostResp is the response for /get-host. A nil error means the host exists;
+// the endpoint-not-found code (ERR_NGROK_706) means it does not.
+type GetHostResp struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Error         *Error                 `protobuf:"bytes,1,opt,name=error,proto3" json:"error,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetHostResp) Reset() {
+	*x = GetHostResp{}
+	mi := &file_lib_private_dial_private_dial_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetHostResp) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetHostResp) ProtoMessage() {}
+
+func (x *GetHostResp) ProtoReflect() protoreflect.Message {
+	mi := &file_lib_private_dial_private_dial_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetHostResp.ProtoReflect.Descriptor instead.
+func (*GetHostResp) Descriptor() ([]byte, []int) {
+	return file_lib_private_dial_private_dial_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *GetHostResp) GetError() *Error {
+	if x != nil {
+		return x.Error
+	}
+	return nil
+}
+
+// GetHostPortReq is the request body for /get-hostport.
+type GetHostPortReq struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Host          string                 `protobuf:"bytes,1,opt,name=host,proto3" json:"host,omitempty"`
+	Port          int64                  `protobuf:"varint,2,opt,name=port,proto3" json:"port,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetHostPortReq) Reset() {
+	*x = GetHostPortReq{}
+	mi := &file_lib_private_dial_private_dial_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetHostPortReq) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetHostPortReq) ProtoMessage() {}
+
+func (x *GetHostPortReq) ProtoReflect() protoreflect.Message {
+	mi := &file_lib_private_dial_private_dial_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetHostPortReq.ProtoReflect.Descriptor instead.
+func (*GetHostPortReq) Descriptor() ([]byte, []int) {
+	return file_lib_private_dial_private_dial_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *GetHostPortReq) GetHost() string {
+	if x != nil {
+		return x.Host
+	}
+	return ""
+}
+
+func (x *GetHostPortReq) GetPort() int64 {
+	if x != nil {
+		return x.Port
+	}
+	return 0
+}
+
+// GetHostPortResp is the response for /get-hostport.
+type GetHostPortResp struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Error         *Error                 `protobuf:"bytes,1,opt,name=error,proto3" json:"error,omitempty"`
+	EndpointId    string                 `protobuf:"bytes,2,opt,name=endpoint_id,json=endpointId,proto3" json:"endpoint_id,omitempty"`
+	Metadata      map[string]string      `protobuf:"bytes,3,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetHostPortResp) Reset() {
+	*x = GetHostPortResp{}
+	mi := &file_lib_private_dial_private_dial_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetHostPortResp) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetHostPortResp) ProtoMessage() {}
+
+func (x *GetHostPortResp) ProtoReflect() protoreflect.Message {
+	mi := &file_lib_private_dial_private_dial_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetHostPortResp.ProtoReflect.Descriptor instead.
+func (*GetHostPortResp) Descriptor() ([]byte, []int) {
+	return file_lib_private_dial_private_dial_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *GetHostPortResp) GetError() *Error {
+	if x != nil {
+		return x.Error
+	}
+	return nil
+}
+
+func (x *GetHostPortResp) GetEndpointId() string {
+	if x != nil {
+		return x.EndpointId
+	}
+	return ""
+}
+
+func (x *GetHostPortResp) GetMetadata() map[string]string {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 var File_lib_private_dial_private_dial_proto protoreflect.FileDescriptor
 
 const file_lib_private_dial_private_dial_proto_rawDesc = "" +
@@ -691,7 +951,26 @@ const file_lib_private_dial_private_dial_proto_rawDesc = "" +
 	"\vDialTrailer\x12\x1d\n" +
 	"\n" +
 	"error_code\x18\x01 \x01(\tR\terrorCode\x12#\n" +
-	"\rerror_message\x18\x02 \x01(\tR\ferrorMessageB\"Z go.ngrok.com/lib/pb_private_dialb\x06proto3"
+	"\rerror_message\x18\x02 \x01(\tR\ferrorMessage\"5\n" +
+	"\x05Error\x12\x12\n" +
+	"\x04code\x18\x01 \x01(\tR\x04code\x12\x18\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage\" \n" +
+	"\n" +
+	"GetHostReq\x12\x12\n" +
+	"\x04host\x18\x01 \x01(\tR\x04host\"8\n" +
+	"\vGetHostResp\x12)\n" +
+	"\x05error\x18\x01 \x01(\v2\x13.private_dial.ErrorR\x05error\"8\n" +
+	"\x0eGetHostPortReq\x12\x12\n" +
+	"\x04host\x18\x01 \x01(\tR\x04host\x12\x12\n" +
+	"\x04port\x18\x02 \x01(\x03R\x04port\"\xe3\x01\n" +
+	"\x0fGetHostPortResp\x12)\n" +
+	"\x05error\x18\x01 \x01(\v2\x13.private_dial.ErrorR\x05error\x12\x1f\n" +
+	"\vendpoint_id\x18\x02 \x01(\tR\n" +
+	"endpointId\x12G\n" +
+	"\bmetadata\x18\x03 \x03(\v2+.private_dial.GetHostPortResp.MetadataEntryR\bmetadata\x1a;\n" +
+	"\rMetadataEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B\"Z go.ngrok.com/lib/pb_private_dialb\x06proto3"
 
 var (
 	file_lib_private_dial_private_dial_proto_rawDescOnce sync.Once
@@ -705,7 +984,7 @@ func file_lib_private_dial_private_dial_proto_rawDescGZIP() []byte {
 	return file_lib_private_dial_private_dial_proto_rawDescData
 }
 
-var file_lib_private_dial_private_dial_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
+var file_lib_private_dial_private_dial_proto_msgTypes = make([]protoimpl.MessageInfo, 19)
 var file_lib_private_dial_private_dial_proto_goTypes = []any{
 	(*SessionReq)(nil),          // 0: private_dial.SessionReq
 	(*SessionAck)(nil),          // 1: private_dial.SessionAck
@@ -717,26 +996,35 @@ var file_lib_private_dial_private_dial_proto_goTypes = []any{
 	(*DialReq)(nil),             // 7: private_dial.DialReq
 	(*DialResp)(nil),            // 8: private_dial.DialResp
 	(*DialTrailer)(nil),         // 9: private_dial.DialTrailer
-	nil,                         // 10: private_dial.SessionReq.MetadataEntry
-	nil,                         // 11: private_dial.DialReq.MetadataEntry
-	nil,                         // 12: private_dial.DialResp.MetadataEntry
-	(*durationpb.Duration)(nil), // 13: google.protobuf.Duration
+	(*Error)(nil),               // 10: private_dial.Error
+	(*GetHostReq)(nil),          // 11: private_dial.GetHostReq
+	(*GetHostResp)(nil),         // 12: private_dial.GetHostResp
+	(*GetHostPortReq)(nil),      // 13: private_dial.GetHostPortReq
+	(*GetHostPortResp)(nil),     // 14: private_dial.GetHostPortResp
+	nil,                         // 15: private_dial.SessionReq.MetadataEntry
+	nil,                         // 16: private_dial.DialReq.MetadataEntry
+	nil,                         // 17: private_dial.DialResp.MetadataEntry
+	nil,                         // 18: private_dial.GetHostPortResp.MetadataEntry
+	(*durationpb.Duration)(nil), // 19: google.protobuf.Duration
 }
 var file_lib_private_dial_private_dial_proto_depIdxs = []int32{
-	10, // 0: private_dial.SessionReq.metadata:type_name -> private_dial.SessionReq.MetadataEntry
-	13, // 1: private_dial.SessionAck.ping_interval:type_name -> google.protobuf.Duration
+	15, // 0: private_dial.SessionReq.metadata:type_name -> private_dial.SessionReq.MetadataEntry
+	19, // 1: private_dial.SessionAck.ping_interval:type_name -> google.protobuf.Duration
 	2,  // 2: private_dial.ControlFrame.ping:type_name -> private_dial.Ping
 	4,  // 3: private_dial.ControlFrame.please_drain:type_name -> private_dial.PleaseDrain
 	5,  // 4: private_dial.ControlFrame.session_error:type_name -> private_dial.SessionError
 	3,  // 5: private_dial.ControlFrame.pong:type_name -> private_dial.Pong
-	11, // 6: private_dial.DialReq.metadata:type_name -> private_dial.DialReq.MetadataEntry
+	16, // 6: private_dial.DialReq.metadata:type_name -> private_dial.DialReq.MetadataEntry
 	0,  // 7: private_dial.DialReq.session_req:type_name -> private_dial.SessionReq
-	12, // 8: private_dial.DialResp.metadata:type_name -> private_dial.DialResp.MetadataEntry
-	9,  // [9:9] is the sub-list for method output_type
-	9,  // [9:9] is the sub-list for method input_type
-	9,  // [9:9] is the sub-list for extension type_name
-	9,  // [9:9] is the sub-list for extension extendee
-	0,  // [0:9] is the sub-list for field type_name
+	17, // 8: private_dial.DialResp.metadata:type_name -> private_dial.DialResp.MetadataEntry
+	10, // 9: private_dial.GetHostResp.error:type_name -> private_dial.Error
+	10, // 10: private_dial.GetHostPortResp.error:type_name -> private_dial.Error
+	18, // 11: private_dial.GetHostPortResp.metadata:type_name -> private_dial.GetHostPortResp.MetadataEntry
+	12, // [12:12] is the sub-list for method output_type
+	12, // [12:12] is the sub-list for method input_type
+	12, // [12:12] is the sub-list for extension type_name
+	12, // [12:12] is the sub-list for extension extendee
+	0,  // [0:12] is the sub-list for field type_name
 }
 
 func init() { file_lib_private_dial_private_dial_proto_init() }
@@ -756,7 +1044,7 @@ func file_lib_private_dial_private_dial_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_lib_private_dial_private_dial_proto_rawDesc), len(file_lib_private_dial_private_dial_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   13,
+			NumMessages:   19,
 			NumExtensions: 0,
 			NumServices:   0,
 		},


### PR DESCRIPTION
Fixes https://linear.app/ngrok/issue/AGENT-617

- Add Dialer.GetHost(ctx, host) (bool, error) implementing the unary /get-host endpoint, so a client can answer dig foo.internal with an A record or NXDOMAIN without dialing (no port required).
- Vendor the get-host protobuf messages (Error, GetHostReq/Resp, plus GetHostPortReq/Resp) by regenerating the private_dial stub.
- Interpret the in-band GetHostResp.Error: nil -> exists; the endpoint-not-found code (ERR_NGROK_706) -> NXDOMAIN; any other code -> a privatedial.Error, so auth/draining/transient failures are never mistaken for a negative DNS answer.
- Add a unaryRoundTrip helper for the unary /get-* path, reusing the existing auth, length-prefixed protobuf, stale-conn and trailer-error machinery.