### PR TITLE
Reduce integration test HTTP flakes

### DIFF
--- a/internal/integration_tests/agent_tls_termination_test.go
+++ b/internal/integration_tests/agent_tls_termination_test.go
@@ -1,7 +1,10 @@
 package integration_tests
 
 import (
+	"context"
 	"crypto/tls"
+	"fmt"
+	"net"
 	"net/url"
 	"strings"
 	"testing"
@@ -10,9 +13,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.ngrok.com/ngrok/v2"
-	"golang.ngrok.com/ngrok/v2/internal/testutil"
 	"golang.ngrok.com/ngrok/v2/internal/tlstest"
 )
+
+type tlsHandlerResult struct {
+	message string
+	err     error
+}
 
 // TestAgentTLSTerminationIntegration tests agent-based TLS termination with custom certificates
 func TestAgentTLSTerminationIntegration(t *testing.T) {
@@ -28,118 +35,154 @@ func TestAgentTLSTerminationIntegration(t *testing.T) {
 	// Setup agent
 	agent, ctx := SetupAgent(t)
 
-	// Setup synchronization primitives
-	handlerReady := testutil.NewSyncPoint()
-	requestComplete := testutil.NewSyncPoint()
-	messageChan := make(chan string, 1)
-	done := make(chan struct{})
-
 	// Create a TLS listener with TLS termination
 	config := &tls.Config{
 		Certificates: []tls.Certificate{*cert},
 	}
 	listener, err := agent.Listen(ctx, ngrok.WithURL("tls://"), ngrok.WithAgentTLSTermination(config))
 	require.NoError(t, err, "Failed to create listener with TLS termination")
-	defer listener.Close()
 
 	// Verify the agent is configured with our TLS config
 	require.NotNil(t, listener.AgentTLSTermination(), "AgentTLSTermination should return our TLS config")
 
-	// Log the endpoint URL
 	endpointURL := listener.URL().String()
 	t.Logf("TLS endpoint URL: %s", endpointURL)
 
-	// Start a goroutine to handle incoming connections
+	// results carries each handled connection's outcome. It is never closed; the
+	// handler goroutine is the only sender and stops when the listener is closed.
+	// Buffered generously so retry/probe connections during endpoint propagation
+	// can't block the accept loop.
+	results := make(chan tlsHandlerResult, 256)
+	stopHandler := make(chan struct{})
+	handlerDone := make(chan struct{})
+
+	// Accept connections in a loop so that every dial attempt made while the
+	// endpoint is still propagating to ngrok's edge is serviced. The goroutine
+	// must never touch testing.T: listener.Close() during cleanup unblocks
+	// Accept with an error, which would otherwise race the test's completion.
 	go func() {
-		defer close(done)
+		defer close(handlerDone)
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				// Expected once the listener is closed during cleanup.
+				return
+			}
 
-		// Signal that we're ready to accept connections
-		handlerReady.Signal()
+			func() {
+				defer conn.Close()
+				// Don't let a single stalled connection wedge the accept loop.
+				_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
 
-		// Accept a connection - this should be already TLS terminated
-		conn, err := listener.Accept()
-		assert.NoError(t, err, "Failed to accept connection")
-		if err != nil {
-			return
+				message, err := serveTCPMessage(conn)
+				select {
+				case results <- tlsHandlerResult{message: message, err: err}:
+				case <-stopHandler:
+				}
+			}()
 		}
-		defer conn.Close()
-		t.Log("Connection accepted")
-
-		// Handle the TCP connection using our utility function
-		message, err := HandleTCPConnection(t, conn)
-		assert.NoError(t, err, "Failed to handle TCP connection")
-		if err != nil {
-			return
-		}
-		t.Logf("Received data from client: %q", message)
-		messageChan <- message
-
-		// Note: The HandleTCPConnection function has already sent a response
-
-		// Signal that the request is complete
-		requestComplete.Signal()
 	}()
 
-	// Wait for the handler to be ready to accept connections
-	handlerReady.Wait(t)
+	// Cleanup: stop the handler, close the listener to unblock Accept, then wait
+	// for the goroutine to exit so it can't outlive the test.
+	defer func() {
+		close(stopHandler)
+		_ = listener.Close()
+		select {
+		case <-handlerDone:
+		case <-time.After(5 * time.Second):
+			t.Error("timed out waiting for TLS handler to exit")
+		}
+	}()
 
-	// Expected message
-	expectedMessage := "TLS test payload"
-
-	// Parse the URL to get the host and port
+	// Parse the URL to get the host and port (default to 443 for TLS).
 	u, err := url.Parse(endpointURL)
 	require.NoError(t, err, "Failed to parse URL")
-
-	// Make sure we have a port (default to 443 for HTTPS)
 	host := u.Host
 	if !strings.Contains(host, ":") {
 		host = host + ":443"
 	}
 
-	// Connect to the endpoint using TLS
 	clientConfig := &tls.Config{
 		InsecureSkipVerify: true, // Skip verification for integration test
 	}
+	const expectedResponse = "Message received"
 
-	t.Logf("Connecting to TLS endpoint: %s (host: %s)", endpointURL, host)
-	conn, err := tls.Dial("tcp", host, clientConfig)
-	require.NoError(t, err, "Failed to connect to TLS endpoint")
-	defer conn.Close()
+	// Retry the full TLS round trip until the endpoint propagates to the edge and
+	// routes to our listener. Each attempt uses a unique payload so the handler
+	// result can be correlated to the specific connection whose response we read.
+	retryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
 
-	// Send the test message
-	_, err = conn.Write([]byte(expectedMessage))
-	require.NoError(t, err, "Failed to send data")
+	var lastErr error
+	for attempt := 1; ; attempt++ {
+		if retryCtx.Err() != nil {
+			require.Failf(t, "TLS endpoint did not become ready", "last error: %v", lastErr)
+		}
 
-	// Read the response
-	buf := make([]byte, 1024)
-	n, err := conn.Read(buf)
-	require.NoError(t, err, "Failed to read response")
-	respBody := string(buf[:n])
+		message := fmt.Sprintf("TLS test payload %d", attempt)
+		respBody, err := tryTLSRoundTrip(retryCtx, host, clientConfig, message)
+		if err == nil && respBody == expectedResponse {
+			actualMessage, err := waitForHandlerResult(retryCtx, results, message)
+			require.NoError(t, err, "handler should receive the message for the successful round trip")
+			assert.Equal(t, message, actualMessage, "Message should match what was sent")
+			assert.Equal(t, expectedResponse, respBody, "Response body should match expected")
+			return
+		}
 
-	// Wait for the message to be received with timeout
-	var actualMessage string
-	select {
-	case actualMessage = <-messageChan:
-		// Received the message
-	case <-time.After(1 * time.Second):
-		require.Fail(t, "Timed out waiting for request processing")
+		if err != nil {
+			lastErr = err
+		} else {
+			lastErr = fmt.Errorf("unexpected response body %q", respBody)
+		}
+
+		select {
+		case <-time.After(250 * time.Millisecond):
+		case <-retryCtx.Done():
+		}
+	}
+}
+
+// tryTLSRoundTrip performs a single TLS dial, writes message, and reads the
+// response, all bounded by ctx and per-connection deadlines.
+func tryTLSRoundTrip(ctx context.Context, host string, clientConfig *tls.Config, message string) (string, error) {
+	dialer := tls.Dialer{
+		NetDialer: &net.Dialer{Timeout: 5 * time.Second},
+		Config:    clientConfig,
 	}
 
-	// Check that the message received matches what was sent
-	assert.Equal(t, expectedMessage, actualMessage, "Message should match what was sent")
+	conn, err := dialer.DialContext(ctx, "tcp", host)
+	if err != nil {
+		return "", err
+	}
+	defer conn.Close()
 
-	// Wait for the request to complete
-	requestComplete.Wait(t)
+	_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
 
-	// Verify the response body
-	expectedResponse := "Message received"
-	assert.Equal(t, expectedResponse, respBody, "Response body should match expected")
+	if _, err := conn.Write([]byte(message)); err != nil {
+		return "", err
+	}
 
-	// Wait for the goroutine to finish with timeout
-	select {
-	case <-done:
-		// Handler finished
-	case <-time.After(1 * time.Second):
-		require.Fail(t, "Timed out waiting for handler to finish")
+	buf := make([]byte, 1024)
+	n, err := conn.Read(buf)
+	if err != nil {
+		return "", err
+	}
+	return string(buf[:n]), nil
+}
+
+// waitForHandlerResult waits for the handler result matching expectedMessage,
+// skipping stale results from earlier retry attempts.
+func waitForHandlerResult(ctx context.Context, results <-chan tlsHandlerResult, expectedMessage string) (string, error) {
+	for {
+		select {
+		case result := <-results:
+			if result.message != expectedMessage {
+				continue // stale result from an earlier retry/probe attempt
+			}
+			return result.message, result.err
+		case <-ctx.Done():
+			return "", fmt.Errorf("timed out waiting for handler result for %q: %w", expectedMessage, ctx.Err())
+		}
 	}
 }

--- a/internal/integration_tests/early_response_test.go
+++ b/internal/integration_tests/early_response_test.go
@@ -46,6 +46,7 @@ func TestEarlyResponseLargeUpload(t *testing.T) {
 
 	ngrokURL := forwarder.URL().String()
 	t.Logf("Forwarder URL: %s", ngrokURL)
+	WaitForForwarderReady(t, ngrokURL)
 
 	t.Run("small body succeeds", func(t *testing.T) {
 		resp, err := MakeHTTPRequest(ctx, t, ngrokURL, "small payload")

--- a/internal/integration_tests/forward_test.go
+++ b/internal/integration_tests/forward_test.go
@@ -55,6 +55,7 @@ func TestForward(t *testing.T) {
 	// Get the ngrok URL
 	ngrokURL := forwarder.URL().String()
 	t.Logf("Forwarder URL: %s", ngrokURL)
+	WaitForForwarderReady(t, ngrokURL)
 
 	// Signal that forwarding is ready
 	forwarderReady.Signal()

--- a/internal/integration_tests/http2_test.go
+++ b/internal/integration_tests/http2_test.go
@@ -65,6 +65,7 @@ func TestUpstreamProtocolHTTP2(t *testing.T) {
 		// Get the ngrok URL
 		ngrokURL := forwarder.URL().String()
 		t.Logf("Forwarder URL: %s", ngrokURL)
+		WaitForForwarderReady(t, ngrokURL)
 
 		// Send a request to the ngrok URL
 		message := "Testing HTTP version"

--- a/internal/integration_tests/listen_http_test.go
+++ b/internal/integration_tests/listen_http_test.go
@@ -2,11 +2,8 @@ package integration_tests
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"golang.ngrok.com/ngrok/v2/internal/testutil"
 )
 
 // TestListenAndHTTPRequest tests the basic functionality of listening for HTTP requests
@@ -22,71 +19,8 @@ func TestListenAndHTTPRequest(t *testing.T) {
 	// Expected message
 	expectedMessage := "Hello, ngrok!"
 
-	// Create synchronization points
-	handlerReady := testutil.NewSyncPoint()
-	requestComplete := testutil.NewSyncPoint()
-	messageChan := make(chan string, 1)
-	done := make(chan struct{})
-
-	// Start a goroutine to handle a single request
-	go func() {
-		defer close(done)
-
-		// Accept a connection
-		t.Log("Waiting for connection...")
-		// Signal that we're ready to accept connections
-		handlerReady.Signal()
-
-		conn, err := listener.Accept()
-		if err != nil {
-			assert.NoError(t, err, "Failed to accept connection")
-			return
-		}
-		defer conn.Close()
-		t.Log("Connection accepted")
-
-		// Handle the HTTP request using the utility function
-		message, err := HandleHTTPRequest(t, conn)
-		assert.NoError(t, err, "Failed to handle HTTP request")
-		if err != nil {
-			return
-		}
-		messageChan <- message
-
-		// Signal that the request is complete
-		requestComplete.Signal()
-	}()
-
-	// Wait for the handler to be ready to accept connections
-	handlerReady.Wait(t)
-
-	// Make HTTP request
-	resp, err := MakeHTTPRequest(ctx, t, listener.URL().String(), expectedMessage)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer resp.Body.Close()
-
-	// Wait for the message to be received with timeout
-	var actualMessage string
-	select {
-	case actualMessage = <-messageChan:
-		// Received the message
-	case <-time.After(500 * time.Millisecond):
-		require.Fail(t, "Timed out waiting for request processing")
-	}
+	actualMessage := MakeListenerHTTPRequest(ctx, t, listener, expectedMessage)
 
 	// Check that the message received matches what was sent
 	assert.Equal(t, expectedMessage, actualMessage, "Message should match what was sent")
-
-	// Wait for the request to complete
-	requestComplete.Wait(t)
-
-	// Wait for the goroutine to finish with timeout
-	select {
-	case <-done:
-		// Handler finished
-	case <-time.After(500 * time.Millisecond):
-		require.Fail(t, "Timed out waiting for handler to finish")
-	}
 }

--- a/internal/integration_tests/listen_http_url_test.go
+++ b/internal/integration_tests/listen_http_url_test.go
@@ -2,12 +2,9 @@ package integration_tests
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"golang.ngrok.com/ngrok/v2"
-	"golang.ngrok.com/ngrok/v2/internal/testutil"
 )
 
 // TestListenWithHTTPURL tests using WithURL to specify an http URL
@@ -27,65 +24,8 @@ func TestListenWithHTTPURL(t *testing.T) {
 	// Expected message
 	expectedMessage := "HTTP Test"
 
-	// Create synchronization points
-	handlerReady := testutil.NewSyncPoint()
-	requestComplete := testutil.NewSyncPoint()
-	messageChan := make(chan string, 1)
-	done := make(chan struct{})
-
-	// Start a goroutine to handle a single request
-	go func() {
-		defer close(done)
-
-		// Accept a connection
-		t.Log("Waiting for connection...")
-		// Signal that we're ready to accept connections
-		handlerReady.Signal()
-
-		conn, err := listener.Accept()
-		require.NoError(t, err, "Failed to accept connection")
-		defer conn.Close()
-		t.Log("Connection accepted")
-
-		// Handle the HTTP request using the utility function
-		message, err := HandleHTTPRequest(t, conn)
-		require.NoError(t, err, "Failed to handle HTTP request")
-		messageChan <- message
-
-		// Signal that the request is complete
-		requestComplete.Signal()
-	}()
-
-	// Wait for the handler to be ready to accept connections
-	handlerReady.Wait(t)
-
-	// Make HTTP request
-	resp, err := MakeHTTPRequest(ctx, t, listener.URL().String(), expectedMessage)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer resp.Body.Close()
-
-	// Wait for the message to be received with timeout
-	var actualMessage string
-	select {
-	case actualMessage = <-messageChan:
-		// Received the message
-	case <-time.After(500 * time.Millisecond):
-		require.Fail(t, "Timed out waiting for request processing")
-	}
+	actualMessage := MakeListenerHTTPRequest(ctx, t, listener, expectedMessage)
 
 	// Check that the message received matches what was sent
 	assert.Equal(t, expectedMessage, actualMessage, "Message should match what was sent")
-
-	// Wait for the request to complete
-	requestComplete.Wait(t)
-
-	// Wait for the goroutine to finish with timeout
-	select {
-	case <-done:
-		// Handler finished
-	case <-time.After(500 * time.Millisecond):
-		require.Fail(t, "Timed out waiting for handler to finish")
-	}
 }

--- a/internal/integration_tests/listen_https_test.go
+++ b/internal/integration_tests/listen_https_test.go
@@ -2,12 +2,9 @@ package integration_tests
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"golang.ngrok.com/ngrok/v2"
-	"golang.ngrok.com/ngrok/v2/internal/testutil"
 )
 
 // TestListenWithHTTPSURL tests using WithURL to specify an https URL
@@ -27,71 +24,8 @@ func TestListenWithHTTPSURL(t *testing.T) {
 	// Expected message
 	expectedMessage := "HTTPS Test"
 
-	// Create synchronization points
-	handlerReady := testutil.NewSyncPoint()
-	requestComplete := testutil.NewSyncPoint()
-	messageChan := make(chan string, 1)
-	done := make(chan struct{})
-
-	// Start a goroutine to handle a single request
-	go func() {
-		defer close(done)
-
-		// Accept a connection
-		t.Log("Waiting for connection...")
-		// Signal that we're ready to accept connections
-		handlerReady.Signal()
-
-		conn, err := listener.Accept()
-		assert.NoError(t, err, "Failed to accept connection")
-		if err != nil {
-			return
-		}
-		defer conn.Close()
-		t.Log("Connection accepted")
-
-		// Handle the HTTP request using the utility function
-		message, err := HandleHTTPRequest(t, conn)
-		assert.NoError(t, err, "Failed to handle HTTP request")
-		if err != nil {
-			return
-		}
-		messageChan <- message
-
-		// Signal that the request is complete
-		requestComplete.Signal()
-	}()
-
-	// Wait for the handler to be ready to accept connections
-	handlerReady.Wait(t)
-
-	// Make HTTP request
-	resp, err := MakeHTTPRequest(ctx, t, listener.URL().String(), expectedMessage)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer resp.Body.Close()
-
-	// Wait for the message to be received with timeout
-	var actualMessage string
-	select {
-	case actualMessage = <-messageChan:
-		// Received the message
-	case <-time.After(500 * time.Millisecond):
-		require.Fail(t, "Timed out waiting for request processing")
-	}
+	actualMessage := MakeListenerHTTPRequest(ctx, t, listener, expectedMessage)
 
 	// Check that the message received matches what was sent
 	assert.Equal(t, expectedMessage, actualMessage, "Message should match what was sent")
-
-	// Wait for the request to complete
-	requestComplete.Wait(t)
-
-	// Wait for the goroutine to finish with timeout
-	select {
-	case <-done:
-		// Handler finished
-	case <-time.After(500 * time.Millisecond):
-		require.Fail(t, "Timed out waiting for handler to finish")
-	}
 }

--- a/internal/integration_tests/proxy_proto_test.go
+++ b/internal/integration_tests/proxy_proto_test.go
@@ -228,7 +228,7 @@ func handleTCPConnection(t *testing.T, conn net.Conn, reader *bufio.Reader, srcA
 func connectHTTPSClient(ctx context.Context, t *testing.T, endpointURL string) {
 	// Use MakeHTTPRequest to send test message
 	message := "Test message for PROXY protocol"
-	resp, err := MakeHTTPRequest(ctx, t, endpointURL, message)
+	resp, err := MakeHTTPRequestWhenEndpointReady(ctx, t, endpointURL, message)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/integration_tests/test_utils.go
+++ b/internal/integration_tests/test_utils.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -17,6 +18,16 @@ import (
 	"golang.ngrok.com/ngrok/v2"
 	"golang.ngrok.com/ngrok/v2/internal/testcontext"
 )
+
+type httpStatusError struct {
+	URL        string
+	Status     string
+	StatusCode int
+}
+
+func (e *httpStatusError) Error() string {
+	return fmt.Sprintf("post %s: http %s", e.URL, e.Status)
+}
 
 // SkipIfOffline skips the test if NGROK_TEST_ONLINE environment variable is not set
 func SkipIfOffline(t *testing.T) {
@@ -115,21 +126,112 @@ func MakeHTTPRequest(ctx context.Context, tb testing.TB, url string, message str
 		return resp, fmt.Errorf("post %s: %v", url, err)
 	}
 	if resp.StatusCode != http.StatusOK {
-		return resp, fmt.Errorf("post %s: http %s", url, resp.Status)
+		return resp, &httpStatusError{
+			URL:        url,
+			Status:     resp.Status,
+			StatusCode: resp.StatusCode,
+		}
 	}
 	return resp, nil
 }
 
-// WaitForForwarderReady polls the forwarder endpoint until it responds or times out
-func WaitForForwarderReady(t *testing.T, url string) {
-	client := &http.Client{Timeout: 100 * time.Millisecond}
-	for start := time.Now(); time.Since(start) < 500*time.Millisecond; {
-		resp, err := client.Get(url)
+// MakeHTTPRequestWhenEndpointReady retries transient 404 responses that can
+// occur while a freshly-created endpoint is propagating through ngrok's edge.
+func MakeHTTPRequestWhenEndpointReady(ctx context.Context, tb testing.TB, url string, message string) (*http.Response, error) {
+	tb.Helper()
+
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		resp, err := MakeHTTPRequest(ctx, tb, url, message)
 		if err == nil {
+			return resp, nil
+		}
+		if resp != nil {
 			resp.Body.Close()
+		}
+
+		var statusErr *httpStatusError
+		if !errors.As(err, &statusErr) || statusErr.StatusCode != http.StatusNotFound {
+			return nil, err
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, fmt.Errorf("post %s: endpoint did not become ready: %w", url, err)
+		}
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("post %s: endpoint did not become ready after 30s: %w", url, err)
+		}
+
+		time.Sleep(250 * time.Millisecond)
+	}
+}
+
+type httpListenerResult struct {
+	message string
+	err     error
+}
+
+func serveOneHTTPRequest(listener ngrok.EndpointListener) <-chan httpListenerResult {
+	result := make(chan httpListenerResult, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			result <- httpListenerResult{err: fmt.Errorf("accept connection: %w", err)}
 			return
 		}
-		time.Sleep(10 * time.Millisecond)
+		defer conn.Close()
+
+		message, err := handleHTTPRequest(conn)
+		if err != nil {
+			result <- httpListenerResult{err: fmt.Errorf("handle HTTP request: %w", err)}
+			return
+		}
+
+		result <- httpListenerResult{message: message}
+	}()
+	return result
+}
+
+func MakeListenerHTTPRequest(ctx context.Context, tb testing.TB, listener ngrok.EndpointListener, message string) string {
+	tb.Helper()
+
+	result := serveOneHTTPRequest(listener)
+	resp, err := MakeHTTPRequestWhenEndpointReady(ctx, tb, listener.URL().String(), message)
+	require.NoError(tb, err)
+	defer resp.Body.Close()
+
+	select {
+	case handled := <-result:
+		require.NoError(tb, handled.err)
+		return handled.message
+	case <-time.After(5 * time.Second):
+		tb.Fatal("timed out waiting for request processing")
+		return ""
+	}
+}
+
+// WaitForForwarderReady polls the forwarder endpoint until ngrok's edge is
+// actually routing traffic to it, or the timeout elapses.
+//
+// A freshly-created endpoint takes time to propagate to ngrok's edge. Until it
+// has, the edge responds with 404 even though the agent session is up, so a
+// successful HTTP response alone does not mean the endpoint is ready - we must
+// keep polling until the edge stops returning 404. Any other status (200 from a
+// healthy upstream, 502 from an upstream that intentionally fails, etc.) means
+// the edge is routing to the endpoint.
+func WaitForForwarderReady(t *testing.T, url string) {
+	t.Helper()
+	client := &http.Client{Timeout: 5 * time.Second}
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := client.Get(url)
+		if err == nil {
+			status := resp.StatusCode
+			resp.Body.Close()
+			if status != http.StatusNotFound {
+				return
+			}
+		}
+		time.Sleep(250 * time.Millisecond)
 	}
 	t.Logf("Forwarder endpoint didn't become ready in expected time, continuing anyway")
 }
@@ -149,8 +251,12 @@ func MakeTCPConnection(t *testing.T, ctx context.Context, address string) (io.Re
 }
 
 // HandleHTTPRequest processes an HTTP request from a connection and sends a response
-func HandleHTTPRequest(t *testing.T, conn net.Conn) (string, error) {
+func HandleHTTPRequest(t testing.TB, conn net.Conn) (string, error) {
 	t.Helper()
+	return handleHTTPRequest(conn)
+}
+
+func handleHTTPRequest(conn net.Conn) (string, error) {
 	// Create a buffered reader for the connection
 	reader := bufio.NewReader(conn)
 

--- a/internal/integration_tests/test_utils.go
+++ b/internal/integration_tests/test_utils.go
@@ -302,6 +302,13 @@ func handleHTTPRequest(conn net.Conn) (string, error) {
 // HandleTCPConnection reads data from a TCP connection and sends a response
 func HandleTCPConnection(t *testing.T, conn io.ReadWriteCloser) (string, error) {
 	t.Helper()
+	return serveTCPMessage(conn)
+}
+
+// serveTCPMessage is the testing.T-free core of HandleTCPConnection so it can be
+// called from background goroutines without risking testing.T use after the test
+// has completed.
+func serveTCPMessage(conn io.ReadWriteCloser) (string, error) {
 	// Read data from the connection
 	buf := make([]byte, 1024)
 	n, err := conn.Read(buf)

--- a/internal/integration_tests/test_utils.go
+++ b/internal/integration_tests/test_utils.go
@@ -140,7 +140,9 @@ func MakeHTTPRequest(ctx context.Context, tb testing.TB, url string, message str
 func MakeHTTPRequestWhenEndpointReady(ctx context.Context, tb testing.TB, url string, message string) (*http.Response, error) {
 	tb.Helper()
 
-	deadline := time.Now().Add(30 * time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
 	for {
 		resp, err := MakeHTTPRequest(ctx, tb, url, message)
 		if err == nil {
@@ -157,9 +159,6 @@ func MakeHTTPRequestWhenEndpointReady(ctx context.Context, tb testing.TB, url st
 		if err := ctx.Err(); err != nil {
 			return nil, fmt.Errorf("post %s: endpoint did not become ready: %w", url, err)
 		}
-		if time.Now().After(deadline) {
-			return nil, fmt.Errorf("post %s: endpoint did not become ready after 30s: %w", url, err)
-		}
 
 		time.Sleep(250 * time.Millisecond)
 	}
@@ -170,8 +169,14 @@ type httpListenerResult struct {
 	err     error
 }
 
-func serveOneHTTPRequest(listener ngrok.EndpointListener) <-chan httpListenerResult {
+func serveOneHTTPRequest(ctx context.Context, listener ngrok.EndpointListener) <-chan httpListenerResult {
 	result := make(chan httpListenerResult, 1)
+
+	go func() {
+		<-ctx.Done()
+		_ = listener.Close()
+	}()
+
 	go func() {
 		conn, err := listener.Accept()
 		if err != nil {
@@ -194,7 +199,10 @@ func serveOneHTTPRequest(listener ngrok.EndpointListener) <-chan httpListenerRes
 func MakeListenerHTTPRequest(ctx context.Context, tb testing.TB, listener ngrok.EndpointListener, message string) string {
 	tb.Helper()
 
-	result := serveOneHTTPRequest(listener)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	result := serveOneHTTPRequest(ctx, listener)
 	resp, err := MakeHTTPRequestWhenEndpointReady(ctx, tb, listener.URL().String(), message)
 	require.NoError(tb, err)
 	defer resp.Body.Close()

--- a/internal/integration_tests/upstream_dialer_test.go
+++ b/internal/integration_tests/upstream_dialer_test.go
@@ -40,12 +40,6 @@ func (d *erroringDialer) DialContext(ctx context.Context, network, address strin
 	return nil, errors.New("custom dialer test error")
 }
 
-// WaitForCall waits for the dialer to be called with a specified timeout
-func (d *erroringDialer) WaitForCall(t testing.TB, timeout time.Duration) {
-	success := d.syncPoint.WaitTimeout(t, timeout)
-	require.True(t, success, "Timed out waiting for dialer to be called")
-}
-
 // TestUpstreamDialer tests the WithUpstreamDialer functionality
 func TestUpstreamDialer(t *testing.T) {
 	// Mark this test for parallel execution
@@ -69,23 +63,25 @@ func TestUpstreamDialer(t *testing.T) {
 	ngrokURL := forwarder.URL().String()
 	t.Logf("Forwarder URL: %s", ngrokURL)
 
-	// Wait until the edge is routing to the endpoint. Until it propagates the
-	// edge returns 404 without ever dialing the upstream, so the dialer would
-	// never be invoked.
-	WaitForForwarderReady(t, ngrokURL)
-
-	// Now make a request to trigger the dialer
-	t.Logf("Making request to trigger upstream connection...")
-	// The request will fail, but we'll ignore that since we expect it to fail
-	// We're just triggering the ngrok service to use our dialer
-	go func() {
-		_, _ = http.Get(ngrokURL)
-	}()
-
-	// Wait for our dialer to be called with a timeout
+	// A freshly created endpoint takes time to propagate to ngrok's edge; until
+	// it does, requests are rejected at the edge without ever reaching the
+	// agent's dialer. Any request that does reach the agent invokes the custom
+	// dialer, so a dialer call is both our readiness signal and the assertion
+	// under test. Issue requests synchronously (each fully drained, so nothing
+	// outlives the test) until the dialer fires.
 	t.Log("Waiting for dialer to be called...")
-	customDialer.WaitForCall(t, 3*time.Second)
+	client := &http.Client{Timeout: 5 * time.Second}
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		resp, err := client.Get(ngrokURL)
+		if err == nil {
+			_ = resp.Body.Close()
+		}
+		if customDialer.syncPoint.WaitTimeout(t, 250*time.Millisecond) {
+			break
+		}
+		require.False(t, time.Now().After(deadline), "Timed out waiting for custom dialer to be called")
+	}
 
-	// If we got here, the test passed (WaitForCall would have failed if the dialer wasn't called)
 	t.Log("Custom dialer was successfully called")
 }

--- a/internal/integration_tests/upstream_dialer_test.go
+++ b/internal/integration_tests/upstream_dialer_test.go
@@ -69,6 +69,11 @@ func TestUpstreamDialer(t *testing.T) {
 	ngrokURL := forwarder.URL().String()
 	t.Logf("Forwarder URL: %s", ngrokURL)
 
+	// Wait until the edge is routing to the endpoint. Until it propagates the
+	// edge returns 404 without ever dialing the upstream, so the dialer would
+	// never be invoked.
+	WaitForForwarderReady(t, ngrokURL)
+
 	// Now make a request to trigger the dialer
 	t.Logf("Making request to trigger upstream connection...")
 	// The request will fail, but we'll ignore that since we expect it to fail

--- a/internal/integration_tests/url_pooling_test.go
+++ b/internal/integration_tests/url_pooling_test.go
@@ -237,7 +237,7 @@ func TestListenWithURLAndPooling(t *testing.T) {
 			message := fmt.Sprintf("Request %d", requestCount)
 
 			// Make HTTP request with a new connection each time
-			resp, err := MakeHTTPRequest(ctx, t, url, message)
+			resp, err := MakeHTTPRequestWhenEndpointReady(ctx, t, url, message)
 			if err != nil {
 				t.Errorf("Request %d: %v", requestCount, err)
 				goto sleepUntilNextRequest

--- a/internal/integration_tests/websocket_test.go
+++ b/internal/integration_tests/websocket_test.go
@@ -32,6 +32,7 @@ func TestWebSocketUpgrade(t *testing.T) {
 	defer forwarder.Close()
 
 	ngrokURL := forwarder.URL().String()
+	WaitForForwarderReady(t, ngrokURL)
 	// Convert http:// to ws:// for WebSocket connection
 	wsURL := "ws" + strings.TrimPrefix(ngrokURL, "http")
 	t.Logf("WebSocket URL: %s", wsURL)


### PR DESCRIPTION
- Retry transient 404s while newly-created endpoints propagate.
- Add a shared listener request helper for HTTP and HTTPS tests.
- Use endpoint-ready requests in proxy protocol and URL pooling tests.