### PR TITLE
implement receivers for additional session info

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -158,6 +158,23 @@ func (a *agent) Connect(ctx context.Context) error {
 	agentSession.id = sess.AgentSessionID()
 	agentSession.warnings = sess.Warnings()
 
+	// legacy.Session doesn't declare these in its interface, but the
+	// concrete implementation always provides them (the same handshake
+	// fields the v3 ngrok agent reads directly off its own session type).
+	// Surfaced publicly via AgentSessionDetails.
+	type sessionExtras interface {
+		AccountName() string
+		PlanName() string
+		Region() string
+		Banner() string
+	}
+	if extras, ok := sess.(sessionExtras); ok {
+		agentSession.accountName = extras.AccountName()
+		agentSession.planName = extras.PlanName()
+		agentSession.region = extras.Region()
+		agentSession.banner = extras.Banner()
+	}
+
 	// Store in agent
 	a.sess = sess
 	a.agentSession = agentSession

--- a/session.go
+++ b/session.go
@@ -17,12 +17,37 @@ type AgentSession interface {
 	StartedAt() time.Time
 }
 
-// agentSession implements the AgentSession interface.
+// AgentSessionDetails is implemented by AgentSession values that carry
+// account and connection details returned by the ngrok service on connect.
+// Use a type assertion to access it:
+//
+//	details, ok := session.(ngrok.AgentSessionDetails)
+type AgentSessionDetails interface {
+	AgentSession
+
+	// AccountName returns the name of the account this agent session is connected under.
+	AccountName() string
+
+	// PlanName returns the billing plan of the account this agent session is connected under.
+	PlanName() string
+
+	// Region returns the ngrok edge region this session is connected to.
+	Region() string
+
+	// Banner returns any informational banner message sent by the ngrok service on connect.
+	Banner() string
+}
+
+// agentSession implements the AgentSession and AgentSessionDetails interfaces.
 type agentSession struct {
-	id        string
-	warnings  []error
-	agent     Agent
-	startedAt time.Time
+	id          string
+	warnings    []error
+	agent       Agent
+	startedAt   time.Time
+	accountName string
+	planName    string
+	region      string
+	banner      string
 }
 
 func (s *agentSession) ID() string {
@@ -39,4 +64,20 @@ func (s *agentSession) Agent() Agent {
 
 func (s *agentSession) StartedAt() time.Time {
 	return s.startedAt
+}
+
+func (s *agentSession) AccountName() string {
+	return s.accountName
+}
+
+func (s *agentSession) PlanName() string {
+	return s.planName
+}
+
+func (s *agentSession) Region() string {
+	return s.region
+}
+
+func (s *agentSession) Banner() string {
+	return s.banner
 }


### PR DESCRIPTION
Adds a new AgentSessionDetails interface that exposes AccountName(), PlanName(), Region(), and Banner() on an AgentSession. We need these fields to implement the agent connect/disconnect commands. To avoid backwards compatibility issues, this creates a separate interface that we can use via type assertion in the agent (similar to what we did for the endpoint hot reloading with UpdateableEndpointForwarder). I've tested this with the agent cli changes. For now I'm keeping this branch against the private dial branch, but if all looks good, we should merge this to main first, and then rebase the private dial branch so the agent can have both changes 
