### PR TITLE
fix: stop leaking an upstream socket and a goroutine per forwarded HTTP connection

### DIFF
--- a/httpinspect.go
+++ b/httpinspect.go
@@ -21,6 +21,12 @@ import (
 func (e *endpointForwarder) httpServe(proxyConn net.Conn) {
 	target := e.upstreamURL.Load()
 	transport := e.buildHTTPTransport()
+	// This transport is built per inbound connection, so it has to be torn down
+	// per inbound connection too. Nothing else ever closes it: net/http sets no
+	// finalizer on Transport, and an idle upstream connection keeps its read
+	// loop goroutine alive, so an abandoned transport holds its socket open
+	// until the upstream gives up. Deferred so it runs after server.Close().
+	defer transport.CloseIdleConnections()
 
 	rp := &httputil.ReverseProxy{
 		Rewrite: func(pr *httputil.ProxyRequest) {
@@ -73,6 +79,12 @@ func (e *endpointForwarder) buildHTTPTransport() *http.Transport {
 	transport := &http.Transport{
 		TLSClientConfig:   tlsConfig,
 		ForceAttemptHTTP2: e.upstreamProtocol == "http2",
+		// A hand-built Transport leaves this at zero, which net/http reads as
+		// "no limit" - unlike http.DefaultTransport, which uses 90s. Without
+		// it, an idle upstream socket survives for as long as the inbound
+		// connection that created it, which the ngrok edge may hold open for a
+		// long time.
+		IdleConnTimeout: 90 * time.Second,
 	}
 
 	if e.upstreamDialer != nil {

--- a/httpinspect_test.go
+++ b/httpinspect_test.go
@@ -1,0 +1,194 @@
+package ngrok
+
+import (
+	"bufio"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/websocket"
+)
+
+// upstreamConnCounter is an upstream test server that tracks how many
+// connections are currently open. ConnState is installed before the server
+// starts so the counter is race-free.
+type upstreamConnCounter struct {
+	*httptest.Server
+	live atomic.Int64
+}
+
+func newCountingUpstream(t *testing.T, h http.Handler) *upstreamConnCounter {
+	t.Helper()
+
+	u := &upstreamConnCounter{}
+	u.Server = httptest.NewUnstartedServer(h)
+	u.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		switch state {
+		case http.StateNew:
+			u.live.Add(1)
+		case http.StateClosed, http.StateHijacked:
+			u.live.Add(-1)
+		}
+	}
+	u.Start()
+	t.Cleanup(u.Close)
+
+	return u
+}
+
+// waitForLiveConns polls until the live connection count drops to within limit,
+// and reports the final count.
+func (u *upstreamConnCounter) waitForLiveConns(limit int64) int64 {
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) && u.live.Load() > limit {
+		time.Sleep(25 * time.Millisecond)
+	}
+	return u.live.Load()
+}
+
+// newTestForwarder builds an endpointForwarder pointing at the given upstream
+// without an agent or a session. emitConnectionEvent type-asserts on the agent
+// field, and that assertion simply yields ok==false when it is nil, so the
+// event path stays safe to exercise.
+func newTestForwarder(t *testing.T, upstream string) *endpointForwarder {
+	t.Helper()
+
+	u, err := url.Parse(upstream)
+	require.NoError(t, err)
+
+	e := &endpointForwarder{}
+	e.upstreamURL.Store(u)
+
+	return e
+}
+
+// serveEdgeConn drives one inbound edge connection through httpServe: a single
+// request, then the client hangs up. It blocks until httpServe returns.
+func serveEdgeConn(t *testing.T, e *endpointForwarder) {
+	t.Helper()
+
+	edgeClient, edgeServer := net.Pipe()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		e.httpServe(edgeServer)
+	}()
+
+	_, err := io.WriteString(edgeClient, "GET / HTTP/1.1\r\nHost: example.test\r\n\r\n")
+	require.NoError(t, err)
+
+	resp, err := http.ReadResponse(bufio.NewReader(edgeClient), nil)
+	require.NoError(t, err)
+	_, err = io.Copy(io.Discard, resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.NoError(t, edgeClient.Close())
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("httpServe did not return after the edge connection closed")
+	}
+}
+
+// Forwarding an HTTP upstream must not cost a permanent upstream socket per
+// inbound edge connection. The assertion is deliberately "does not scale with
+// N" rather than an exact count, so that it stays meaningful whether the
+// transport is per-connection or shared and pooling idle sockets.
+func TestHTTPServeDoesNotLeakUpstreamConns(t *testing.T) {
+	upstream := newCountingUpstream(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, "ok")
+	}))
+
+	e := newTestForwarder(t, upstream.URL)
+
+	const (
+		n        = 25
+		maxIdle  = 4
+		maxExtra = 10
+	)
+	baseGoroutines := runtime.NumGoroutine()
+
+	for range n {
+		serveEdgeConn(t, e)
+	}
+
+	live := upstream.waitForLiveConns(maxIdle)
+	t.Logf("%d edge connections left %d upstream connections open", n, live)
+	assert.LessOrEqualf(t, live, int64(maxIdle),
+		"upstream connections scale with the number of edge connections: %d left open after %d connections", live, n)
+
+	deadline := time.Now().Add(3 * time.Second)
+	delta := runtime.NumGoroutine() - baseGoroutines
+	for time.Now().Before(deadline) && delta > maxExtra {
+		time.Sleep(25 * time.Millisecond)
+		delta = runtime.NumGoroutine() - baseGoroutines
+	}
+	assert.LessOrEqualf(t, delta, maxExtra,
+		"goroutines scale with the number of edge connections: grew by %d after %d connections", delta, n)
+}
+
+// WebSocket upgrades hijack the connection, taking the upstream socket out of
+// the idle pool. Tearing the transport down must not disturb them. This runs
+// entirely offline: a loopback listener stands in for the ngrok edge.
+func TestHTTPServeWebSocketUpgrade(t *testing.T) {
+	upstream := newCountingUpstream(t, websocket.Handler(func(ws *websocket.Conn) {
+		_, _ = io.Copy(ws, ws)
+	}))
+
+	e := newTestForwarder(t, upstream.URL)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close() //nolint:errcheck
+
+	served := make(chan struct{})
+	go func() {
+		defer close(served)
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		e.httpServe(conn)
+	}()
+
+	origin := "http://" + ln.Addr().String()
+	ws, err := websocket.Dial("ws://"+ln.Addr().String(), "", origin)
+	require.NoError(t, err, "websocket dial through httpServe")
+
+	for _, msg := range []string{"hello", "second", "third"} {
+		_, err := ws.Write([]byte(msg))
+		require.NoError(t, err)
+
+		buf := make([]byte, 256)
+		n, err := ws.Read(buf)
+		require.NoError(t, err)
+		assert.Equal(t, msg, string(buf[:n]), "websocket echo")
+	}
+
+	require.NoError(t, ws.Close())
+
+	select {
+	case <-served:
+	case <-time.After(5 * time.Second):
+		t.Fatal("httpServe did not return after the websocket closed")
+	}
+
+	assert.Zerof(t, upstream.waitForLiveConns(0),
+		"upstream websocket connection was not released")
+}
+
+// A zero IdleConnTimeout means "no limit", which lets an idle upstream socket
+// outlive any reasonable connection lifetime.
+func TestBuildHTTPTransportSetsIdleConnTimeout(t *testing.T) {
+	e := newTestForwarder(t, "http://127.0.0.1:1")
+	assert.NotZero(t, e.buildHTTPTransport().IdleConnTimeout)
+}

--- a/internal/httpx/server.go
+++ b/internal/httpx/server.go
@@ -99,8 +99,8 @@ func (s *ServeConnServer) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 // ServeConn begins serving the given connection.
 // Optionally, the provided 'state' will be made available via the
 // ExtractConnServerState function.
-// Note, the ctx is currently ignored. It should be respected in the future,
-// but it fails unit tests, so it needs some more careful consideration.
+// If ctx is canceled, the connection is shut down gracefully: handlers already
+// in flight run to completion, but no further requests are served on it.
 // If an error is returned, it will be 'http.ErrServerClosed', indicating the
 // connection was not served, or a context error.
 func (s *ServeConnServer) ServeConn(ctx context.Context, conn net.Conn, state any) error {
@@ -113,11 +113,17 @@ func (s *ServeConnServer) ServeConn(ctx context.Context, conn net.Conn, state an
 	}
 	defer s.l.RemoveConn(conn)
 
-	go func() {
-		// start terminating this connection if the `ctx` passed into ServeConn gets canceled
-		<-ctx.Done()
-		ac.shut.Shutdown()
-	}()
+	// Start terminating this connection if the `ctx` passed into ServeConn gets
+	// canceled.
+	//
+	// This has to be context.AfterFunc rather than a goroutine parked on
+	// ctx.Done(). Such a goroutine leaks in both directions: with a background
+	// ctx, Done() is nil and it parks forever, and with a long-lived cancelable
+	// ctx it survives until that ctx is canceled, accumulating one parked
+	// goroutine per connection served. AfterFunc registers nothing at all when
+	// Done() is nil, and stop() unregisters the watcher when we return.
+	stop := context.AfterFunc(ctx, func() { ac.shut.Shutdown() })
+	defer stop()
 
 	s.log.Debug("wait")
 	<-ac.shut.C()

--- a/internal/httpx/server_test.go
+++ b/internal/httpx/server_test.go
@@ -1,0 +1,154 @@
+package httpx
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// newTestServer returns a ServeConnServer backed by a trivial handler.
+func newTestServer(t *testing.T) *ServeConnServer {
+	t.Helper()
+
+	server := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = io.WriteString(w, "ok")
+		}),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	srv := NewServeConnServer(server, slog.New(slog.DiscardHandler))
+	go srv.ListenAndServe()              //nolint:errcheck
+	t.Cleanup(func() { server.Close() }) //nolint:errcheck
+
+	return srv
+}
+
+// serveOneConn drives a single connection through ServeConn: one request, then
+// the client hangs up. It blocks until ServeConn returns.
+func serveOneConn(t *testing.T, srv *ServeConnServer, ctx context.Context) {
+	t.Helper()
+
+	client, server := net.Pipe()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		srv.ServeConn(ctx, server, nil) //nolint:errcheck
+	}()
+
+	if _, err := io.WriteString(client, "GET / HTTP/1.1\r\nHost: example.test\r\n\r\n"); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+	resp, err := http.ReadResponse(bufio.NewReader(client), nil)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if _, err := io.Copy(io.Discard, resp.Body); err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	resp.Body.Close() //nolint:errcheck
+	client.Close()    //nolint:errcheck
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ServeConn did not return after the connection closed")
+	}
+}
+
+// waitForGoroutines polls until the goroutine count drops to within limit of
+// base, and reports the final delta.
+func waitForGoroutines(base, limit int) int {
+	deadline := time.Now().Add(3 * time.Second)
+	delta := runtime.NumGoroutine() - base
+	for time.Now().Before(deadline) && delta > limit {
+		time.Sleep(25 * time.Millisecond)
+		delta = runtime.NumGoroutine() - base
+	}
+	return delta
+}
+
+// A background context has a nil Done() channel. A watcher goroutine parked on
+// it would never wake, leaking one goroutine per connection served, forever.
+func TestServeConnNoGoroutineLeakBackgroundCtx(t *testing.T) {
+	srv := newTestServer(t)
+
+	const n = 50
+	base := runtime.NumGoroutine()
+	for range n {
+		serveOneConn(t, srv, context.Background())
+	}
+
+	if delta := waitForGoroutines(base, 10); delta > 10 {
+		t.Errorf("leaked goroutines: count grew by %d after %d connections", delta, n)
+	}
+}
+
+// A long-lived cancelable context is the other half of the leak: a watcher
+// parked on ctx.Done() survives until that context is canceled, so a forwarder
+// that lives for days accumulates one parked goroutine per connection served.
+func TestServeConnNoGoroutineLeakLongLivedCtx(t *testing.T) {
+	srv := newTestServer(t)
+
+	// Deliberately NOT canceled until the test ends, standing in for a context
+	// that lives as long as the endpoint.
+	ctx := t.Context()
+
+	const n = 50
+	base := runtime.NumGoroutine()
+	for range n {
+		serveOneConn(t, srv, ctx)
+	}
+
+	if delta := waitForGoroutines(base, 10); delta > 10 {
+		t.Errorf("leaked goroutines: count grew by %d after %d connections on one long-lived context", delta, n)
+	}
+}
+
+// Canceling the context must release a connection that is sitting idle between
+// keep-alive requests.
+func TestServeConnCtxCancelReleasesIdleConn(t *testing.T) {
+	srv := newTestServer(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client, server := net.Pipe()
+	defer client.Close() //nolint:errcheck
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		srv.ServeConn(ctx, server, nil) //nolint:errcheck
+	}()
+
+	// One request, keep-alive, leaving the connection idle afterwards.
+	if _, err := io.WriteString(client, "GET / HTTP/1.1\r\nHost: example.test\r\n\r\n"); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+	resp, err := http.ReadResponse(bufio.NewReader(client), nil)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	resp.Body.Close() //nolint:errcheck
+
+	select {
+	case <-done:
+		t.Fatal("ServeConn returned while the connection was still usable")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ServeConn did not return after its context was canceled")
+	}
+}


### PR DESCRIPTION
## Summary

Forwarding to an HTTP or HTTPS upstream leaked **one upstream socket and several goroutines per inbound edge connection**, permanently. This was found while testing an ngrok-operator RC, and it reproduces in isolation.

It is a lifecycle bug, not a load bug: the leak is per *connection*, independent of request volume. A long-running agent forwarding HTTP eventually exhausts its file descriptors.

Two independent leaks are fixed here, one commit each.

## Impact and scope

- **Affected:** endpoints forwarding to an `http` or `https` upstream.
- **Not affected:** raw TCP and TLS upstreams. `handleConnection` only routes `isHTTP()` upstreams through `httpServe`; everything else goes through `join()`, which closes both ends.
- **Introduced in** c2ca9c0 ("expose connection and request metrics", #220), which landed between **v2.1.1 and v2.1.2**. Before that commit `handleConnection` always used `join()`.

Measured on `main`, driving 25 inbound connections that are each fully closed afterwards:

| | before | after |
|---|---|---|
| Live upstream sockets | **25** | 0 |
| Goroutine growth | **+75** | 0 |

And for the `httpx` leak in isolation, 50 connections:

| | before | after |
|---|---|---|
| Goroutine growth | **+50** | 0 |

## Leak 1 — an upstream socket per inbound connection

`httpServe` builds a fresh `http.Transport` per inbound edge connection and never closed it. `server.Close()` tears down only the server side.

It is worth being explicit about why the garbage collector does not save us here, because that is the intuition this bug defeats. Three things stack up:

1. `net/http` installs **no finalizer** on `Transport`, so an unreachable transport never has its sockets closed.
2. An idle pooled connection has a background read loop goroutine, and that goroutine keeps the transport **reachable** — so it is not even eligible for collection.
3. The transport is built by hand as `&http.Transport{}`, which leaves `IdleConnTimeout` at its zero value. The stdlib documents zero as **"no limit"**. This is the surprising part: `http.DefaultTransport` sets 90s, so the timeout most people have in mind is a property of the *default* transport, not of `Transport` itself.

Net effect: one orphaned upstream socket, plus its read and write loop goroutines, for every inbound connection — held until the upstream itself decides to hang up.

**Fix:** close the transport when the connection it belongs to finishes, and set a non-zero `IdleConnTimeout`.

The timeout is not merely defense in depth. The transport is only closed once `httpServe` returns, i.e. when the inbound connection closes, and ngrok's edge may hold an inbound connection open for a long time. For that window, `IdleConnTimeout` is the only thing bounding idle upstream sockets.

## Leak 2 — a goroutine per inbound connection

`ServeConnServer.ServeConn` started a goroutine parked on `<-ctx.Done()` to shut the connection down on cancellation. That goroutine leaks in **both** directions:

- **With a non-cancelable context** — `httpServe` passed `context.Background()`, whose `Done()` returns a **nil channel**. A receive on a nil channel blocks forever, so the goroutine parks permanently. One per inbound connection, for the life of the process.
- **With a long-lived cancelable context** — the watcher survives until *that* context is canceled. For a forwarder that runs for days, this accumulates one parked goroutine per connection ever served.

Only the first mode is reachable on `main` today. The second is included because it is the same defect and it becomes the live one as soon as a real context is threaded through, which the follow-up PR does.

**Fix:** `context.AfterFunc` plus `defer stop()`.

```go
stop := context.AfterFunc(ctx, func() { ac.shut.Shutdown() })
defer stop()
```

`AfterFunc` registers nothing at all when `Done()` is nil, which closes the first mode. `defer stop()` unregisters the watcher when `ServeConn` returns, which closes the second. This is the idiom already used in `diagnose.go` (37a39ee).

The doc comment claiming the context is ignored is also removed — it has been wired to connection shutdown since this code landed.

## Tests

New offline tests only; both fail on `main` and pass here.

- `internal/httpx/server_test.go` — the package previously had no tests. Covers both leak modes and pins that canceling a context releases an idle connection.
- `httpinspect_test.go` — builds an `endpointForwarder` directly, with no agent, session, or authtoken required.

Two deliberate test-design choices:

- The upstream-socket assertion is **"does not scale with N"** rather than an exact count, so it stays meaningful in the follow-up PR where the transport becomes shared and legitimately pools a few idle sockets.
- Upstream connections are counted with `httptest.NewUnstartedServer` + `Config.ConnState` installed **before** `Start()`, which keeps the counter race-free. Setting `ConnState` on an already-started server races with the accept loop.

WebSocket upgrades are the one path transport teardown could plausibly disturb, since a hijacked connection is not in the idle pool. That is covered **offline** with a loopback listener standing in for the ngrok edge — no ngrok session needed — because the leak is entirely on the upstream side and does not depend on what the inbound connection is.

## Verification

```
go build ./... && go vet ./...
go test -race -count=3 ./...        # green
go build -C ./examples ./...        # green
```

The full **online** integration suite also passes with `NGROK_TEST_ONLINE=1`, including `TestWebSocketUpgrade` and `TestEarlyResponseLargeUpload`.

No new online tests were added. The existing online suite already exercises the real edge path on every non-fork PR, and an online leak test could not assert tightly here — edge-to-agent connection pooling isn't under test control, so it would have to assert a loose "doesn't grow with N" bound, which is the shape that produced this suite's earlier flakes (4de6a37, 2bcde97).

## Follow-up

Both leaks are symptoms of `httpServe` constructing an entire HTTP stack per inbound connection. The stacked PR on top of this one fixes that root cause and also recovers upstream keep-alive, which is currently impossible. **This PR is deliberately the minimal, backportable change** so it can ship on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
